### PR TITLE
Make status list server URL configurable via realm attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,15 +155,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-core</artifactId>
-            <version>${keycloak.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
             <version>1.15.11</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- JAX-RS Implementation required by tests -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-core</artifactId>
+            <version>6.2.8.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/adorsys/keycloakstatuslist/StatusListJpaEntityProvider.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/StatusListJpaEntityProvider.java
@@ -15,9 +15,8 @@ public class StatusListJpaEntityProvider implements JpaEntityProvider {
     public List<Class<?>> getEntities() {
         logger.debug("Registering entities: StatusListCounterEntity, StatusListMappingEntity");
         return List.of(
-            StatusListCounterEntity.class,
-            StatusListMappingEntity.class
-        );
+                StatusListCounterEntity.class,
+                StatusListMappingEntity.class);
     }
 
     @Override

--- a/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
@@ -72,7 +72,8 @@ public class StatusListProtocolMapper extends AbstractOIDCProtocolMapper
         CONFIG_PROPERTIES = java.util.Collections.unmodifiableList(props);
     }
 
-    private static void addConfigProperty(List<ProviderConfigProperty> props, String name, String label, String type, String helpText,
+    private static void addConfigProperty(List<ProviderConfigProperty> props, String name, String label, String type,
+            String helpText,
             String defaultValue) {
         ProviderConfigProperty property = new ProviderConfigProperty();
         property.setName(name);
@@ -117,7 +118,7 @@ public class StatusListProtocolMapper extends AbstractOIDCProtocolMapper
 
         // Get realm configuration
         StatusListConfig config = new StatusListConfig(session.getContext().getRealm());
-        
+
         // Check if status list is enabled
         if (!config.isEnabled()) {
             logger.debugf("Status list is disabled for realm: %s", realmId);
@@ -141,7 +142,7 @@ public class StatusListProtocolMapper extends AbstractOIDCProtocolMapper
 
         Map<String, String> mapperConfig = mappingModel.getConfig();
         String listId = mapperConfig.getOrDefault(Constants.LIST_ID_PROPERTY, Constants.DEFAULT_LIST_ID);
-        
+
         // Ensure server URL ends with slash for proper concatenation
         String baseUri = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
         String uri = String.format("%s%s", baseUri, listId);
@@ -253,16 +254,18 @@ public class StatusListProtocolMapper extends AbstractOIDCProtocolMapper
         });
     }
 
-    private void sendStatusToServer(long idx, String statusListId, Map<String, String> mapperConfig, StatusListConfig realmConfig) throws IOException {
+    private void sendStatusToServer(long idx, String statusListId, Map<String, String> mapperConfig,
+            StatusListConfig realmConfig) throws IOException {
         String serverUrl = realmConfig.getServerUrl();
         String endpoint = serverUrl + Constants.HTTP_ENDPOINT_PATH;
         String jwtToken = mapperConfig.getOrDefault(Constants.JWT_TOKEN_PROPERTY, Constants.DEFAULT_JWT_TOKEN);
-        
+
         // Use realm auth token if mapper token is not provided
-        if ((jwtToken == null || jwtToken.isEmpty()) && realmConfig.getAuthToken() != null && !realmConfig.getAuthToken().isEmpty()) {
+        if ((jwtToken == null || jwtToken.isEmpty()) && realmConfig.getAuthToken() != null
+                && !realmConfig.getAuthToken().isEmpty()) {
             jwtToken = realmConfig.getAuthToken();
         }
-        
+
         if (jwtToken == null || jwtToken.isEmpty()) {
             logger.error("JWT token is required for status server authentication but is missing or empty.");
             throw new IllegalArgumentException("JWT token is required for status server authentication.");
@@ -296,7 +299,8 @@ public class StatusListProtocolMapper extends AbstractOIDCProtocolMapper
                         "status", statuses);
 
                 String jsonPayload = objectMapper.writeValueAsString(payload);
-                logger.infof("[Attempt %d/%d] Sending POST to %s with payload: %s", currentAttempt, maxRetries, endpoint, jsonPayload);
+                logger.infof("[Attempt %d/%d] Sending POST to %s with payload: %s", currentAttempt, maxRetries,
+                        endpoint, jsonPayload);
 
                 if (!jwtToken.isEmpty()) {
                     httpPost.setHeader(Constants.AUTHORIZATION_HEADER, Constants.BEARER_PREFIX + jwtToken);
@@ -307,7 +311,8 @@ public class StatusListProtocolMapper extends AbstractOIDCProtocolMapper
                 httpClient.execute(httpPost, response -> {
                     if (response.getCode() < 200 || response.getCode() >= 300) {
                         logger.warnf("[Attempt %d/%d] Failed to send status to %s for idx %d: %d %s",
-                                currentAttempt, maxRetries, endpoint, idx, response.getCode(), response.getReasonPhrase());
+                                currentAttempt, maxRetries, endpoint, idx, response.getCode(),
+                                response.getReasonPhrase());
                         throw new IOException("Non-success response: " + response.getCode());
                     } else {
                         logger.debugf("Successfully sent status to %s for idx %d", endpoint, idx);
@@ -317,7 +322,8 @@ public class StatusListProtocolMapper extends AbstractOIDCProtocolMapper
                 success = true;
             } catch (Exception e) {
                 lastException = e;
-                logger.warnf("[Attempt %d/%d] Error sending status to %s for idx %d: %s", currentAttempt, maxRetries, endpoint, idx, e.getMessage());
+                logger.warnf("[Attempt %d/%d] Error sending status to %s for idx %d: %s", currentAttempt, maxRetries,
+                        endpoint, idx, e.getMessage());
                 if (attempt < maxRetries) {
                     try {
                         Thread.sleep(1000L * attempt); // Exponential backoff

--- a/src/main/java/com/adorsys/keycloakstatuslist/config/StatusListConfig.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/config/StatusListConfig.java
@@ -4,7 +4,8 @@ import org.keycloak.models.RealmModel;
 
 /**
  * Configuration holder for the Token Status plugin.
- * This class provides access to the plugin configuration, which can be set in the Keycloak Admin Console.
+ * This class provides access to the plugin configuration, which can be set in
+ * the Keycloak Admin Console.
  */
 public class StatusListConfig {
 
@@ -95,7 +96,8 @@ public class StatusListConfig {
     }
 
     /**
-     * Gets the number of retry attempts when communicating with the status list server.
+     * Gets the number of retry attempts when communicating with the status list
+     * server.
      *
      * @return number of retry attempts
      */

--- a/src/main/java/com/adorsys/keycloakstatuslist/model/StatusListClaim.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/model/StatusListClaim.java
@@ -2,6 +2,7 @@ package com.adorsys.keycloakstatuslist.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.net.URI;
 import java.util.Map;
 
 /**
@@ -54,6 +55,14 @@ public class StatusListClaim {
     }
 
     /**
+     * Overloaded constructor — accepts index as int and URI object.
+     * Internally converts URI to string.
+     */
+    public StatusListClaim(int idx, URI uri) {
+        this(idx, uri.toString());
+    }
+
+    /**
      * Returns the index of the token in the status list.
      * Used by Jackson for serialization and by other components (e.g., Status
      * class) to access the index.
@@ -77,8 +86,7 @@ public class StatusListClaim {
 
     public Map<String, Object> toMap() {
         return Map.of(
-            "idx", idx,
-            "uri", uri
-        );
+                "idx", idx,
+                "uri", uri);
     }
 }

--- a/src/test/java/com/adorsys/keycloakstatuslist/StatusListClientTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/StatusListClientTest.java
@@ -6,18 +6,14 @@ import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.time.Instant;
 
 import com.adorsys.keycloakstatuslist.client.StatusListClient;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.HttpEntity;
-import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,12 +49,12 @@ public class StatusListClientTest {
 
     @Test
     void testPublishRecordServerError() throws IOException {
-        try (MockedStatic<org.apache.hc.client5.http.impl.classic.HttpClients> httpClientsMock =
-                     mockStatic(org.apache.hc.client5.http.impl.classic.HttpClients.class)) {
+        try (MockedStatic<org.apache.hc.client5.http.impl.classic.HttpClients> httpClientsMock = mockStatic(
+                org.apache.hc.client5.http.impl.classic.HttpClients.class)) {
 
             // Create the mock builder
-            org.apache.hc.client5.http.impl.classic.HttpClientBuilder mockBuilder =
-                    mock(org.apache.hc.client5.http.impl.classic.HttpClientBuilder.class);
+            org.apache.hc.client5.http.impl.classic.HttpClientBuilder mockBuilder = mock(
+                    org.apache.hc.client5.http.impl.classic.HttpClientBuilder.class);
 
             // Setup the static mock to return our mock builder
             httpClientsMock.when(HttpClients::custom)
@@ -96,12 +92,12 @@ public class StatusListClientTest {
 
     @Test
     void testPublishRecordNetworkError() throws IOException {
-        try (MockedStatic<org.apache.hc.client5.http.impl.classic.HttpClients> httpClientsMock =
-                     mockStatic(org.apache.hc.client5.http.impl.classic.HttpClients.class)) {
+        try (MockedStatic<org.apache.hc.client5.http.impl.classic.HttpClients> httpClientsMock = mockStatic(
+                org.apache.hc.client5.http.impl.classic.HttpClients.class)) {
 
             // Create the mock builder
-            org.apache.hc.client5.http.impl.classic.HttpClientBuilder mockBuilder =
-                    mock(org.apache.hc.client5.http.impl.classic.HttpClientBuilder.class);
+            org.apache.hc.client5.http.impl.classic.HttpClientBuilder mockBuilder = mock(
+                    org.apache.hc.client5.http.impl.classic.HttpClientBuilder.class);
 
             // Setup the static mock
             httpClientsMock.when(HttpClients::custom)
@@ -155,9 +151,11 @@ public class StatusListClientTest {
 
     @Test
     void testRevokedTokenValidation() throws IOException {
-        try (MockedStatic<org.apache.hc.client5.http.impl.classic.HttpClients> httpClientsMock = mockStatic(org.apache.hc.client5.http.impl.classic.HttpClients.class)) {
+        try (MockedStatic<org.apache.hc.client5.http.impl.classic.HttpClients> httpClientsMock = mockStatic(
+                org.apache.hc.client5.http.impl.classic.HttpClients.class)) {
             // Create and configure the mock builder
-            org.apache.hc.client5.http.impl.classic.HttpClientBuilder mockBuilder = mock(org.apache.hc.client5.http.impl.classic.HttpClientBuilder.class);
+            org.apache.hc.client5.http.impl.classic.HttpClientBuilder mockBuilder = mock(
+                    org.apache.hc.client5.http.impl.classic.HttpClientBuilder.class);
             when(mockBuilder.setDefaultRequestConfig(any())).thenReturn(mockBuilder);
             when(mockBuilder.build()).thenReturn(httpClient);
 

--- a/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
@@ -1,16 +1,18 @@
 package com.adorsys.keycloakstatuslist;
 
+import com.adorsys.keycloakstatuslist.config.StatusListConfig;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.keycloak.models.*;
 import org.keycloak.protocol.oidc.mappers.OIDCAttributeMapperHelper;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.representations.IDToken;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 public class StatusListProtocolMapperTest {
@@ -22,20 +24,24 @@ public class StatusListProtocolMapperTest {
         private ClientSessionContext clientSessionCtx;
         private RealmModel realm;
 
+        // Mocked StatusListConfig to control serverUrl in tests
+        private StatusListConfig statusListConfig;
+
         private interface TestConstants {
                 String TEST_REALM_ID = "test-realm";
                 String TEST_CLIENT_ID = "test-client";
                 String TEST_USER_ID = "user-123";
                 long TEST_INDEX = 42L;
                 long ERROR_INDEX = -1L;
-                String TEST_CLAIM_NAME = "custom_status"; // Configured claim name for tests
-                String TEST_SERVER_URL = "https://example.com/statuslist/";
+                String TEST_CLAIM_NAME = "custom_status";
+                String TEST_SERVER_URL = "https://example.statuslist.com";
                 String TEST_LIST_ID = "99";
         }
 
         @BeforeEach
         public void setUp() {
-                // Spy on the mapper with stubbed methods
+                statusListConfig = mock(StatusListConfig.class);
+
                 mapper = spy(new StatusListProtocolMapper() {
                         @Override
                         protected long getNextIndex(KeycloakSession session) {
@@ -45,34 +51,38 @@ public class StatusListProtocolMapperTest {
                         @Override
                         protected void storeIndexMapping(String statusListId, long idx, String userId, String tokenId,
                                         KeycloakSession session, Map<String, String> mapperConfig,
-                                        com.adorsys.keycloakstatuslist.config.StatusListConfig realmConfig) {
+                                        StatusListConfig realmConfig) {
                                 // no-op
+                        }
+
+                        // Override to return mocked statusListConfig so we can control it in tests
+                        @Override
+                        public StatusListConfig getStatusListConfig(RealmModel realm) {
+                                return statusListConfig;
                         }
                 });
 
-                // Initialize mocks
                 session = mock(KeycloakSession.class);
                 mappingModel = mock(ProtocolMapperModel.class);
                 userSession = mock(UserSessionModel.class);
                 clientSessionCtx = mock(ClientSessionContext.class);
                 realm = mock(RealmModel.class);
 
-                // Configure common mocks
                 configureMocks();
 
-                // Set default configuration
                 when(mappingModel.getConfig()).thenReturn(createDefaultConfig());
+
+                // Default for most tests: config enabled and valid URL
+                when(statusListConfig.isEnabled()).thenReturn(true);
+                when(statusListConfig.getServerUrl()).thenReturn(TestConstants.TEST_SERVER_URL);
         }
 
         private void configureMocks() {
-                // Mock KeycloakContext, RealmModel, and ClientModel
                 KeycloakContext context = mock(KeycloakContext.class);
                 when(session.getContext()).thenReturn(context);
-
                 when(context.getRealm()).thenReturn(realm);
                 when(realm.getId()).thenReturn(TestConstants.TEST_REALM_ID);
 
-                // Mock realm attributes for StatusListConfig
                 when(realm.getAttribute("status-list-enabled")).thenReturn("true");
                 when(realm.getAttribute("status-list-server-url")).thenReturn(TestConstants.TEST_SERVER_URL);
                 when(realm.getAttribute("status-list-auth-token")).thenReturn("test-token");
@@ -84,13 +94,11 @@ public class StatusListProtocolMapperTest {
                 when(context.getClient()).thenReturn(client);
                 when(client.getAttribute(anyString())).thenReturn(null);
 
-                // Mock ClientSession
                 AuthenticatedClientSessionModel clientSession = mock(AuthenticatedClientSessionModel.class);
                 when(clientSessionCtx.getClientSession()).thenReturn(clientSession);
                 when(clientSession.getClient()).thenReturn(client);
                 when(client.getClientId()).thenReturn(TestConstants.TEST_CLIENT_ID);
 
-                // Mock UserSession and UserModel
                 UserModel user = mock(UserModel.class);
                 when(user.getId()).thenReturn(TestConstants.TEST_USER_ID);
                 when(userSession.getUser()).thenReturn(user);
@@ -106,157 +114,107 @@ public class StatusListProtocolMapperTest {
 
         @Test
         public void transformAccessToken_happyPath() {
-                // Arrange
                 AccessToken token = new AccessToken();
-                String expectedUri = TestConstants.TEST_SERVER_URL + TestConstants.TEST_LIST_ID;
+                String expectedUri = TestConstants.TEST_SERVER_URL + "/status-lists/" + TestConstants.TEST_LIST_ID;
 
-                // Act
                 mapper.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
 
-                // Assert
                 Map<String, Object> claims = token.getOtherClaims();
-                assertTrue(claims.containsKey(TestConstants.TEST_CLAIM_NAME),
-                                "Claim 'custom_status' should be present");
+                assertTrue(claims.containsKey(TestConstants.TEST_CLAIM_NAME), "Status claim should be present");
 
                 @SuppressWarnings("unchecked")
                 Map<String, Object> statusClaim = (Map<String, Object>) claims.get(TestConstants.TEST_CLAIM_NAME);
-                assertNotNull(statusClaim, "Status claim map should not be null");
+                assertNotNull(statusClaim);
 
                 @SuppressWarnings("unchecked")
                 Map<String, Object> statusList = (Map<String, Object>) statusClaim.get("status_list");
-                assertNotNull(statusList, "Nested 'status_list' map should not be null");
+                assertNotNull(statusList);
 
-                assertEquals(expectedUri, statusList.get("uri"), "URI should match configured serverUrl/listId");
-                assertEquals(String.valueOf(TestConstants.TEST_INDEX), statusList.get("idx"),
-                                "Idx should match the stringified nextIndex");
+                assertEquals(expectedUri, statusList.get("uri"));
+                assertEquals(String.valueOf(TestConstants.TEST_INDEX), statusList.get("idx"));
 
-                // Verify storeIndexMapping was called with correct parameters
                 verify(mapper, times(1)).storeIndexMapping(
                                 eq(TestConstants.TEST_LIST_ID), eq(TestConstants.TEST_INDEX), anyString(), isNull(),
                                 eq(session), anyMap(),
-                                any(com.adorsys.keycloakstatuslist.config.StatusListConfig.class));
+                                any(StatusListConfig.class));
         }
 
         @Test
         public void transformIDToken_happyPath() {
-                // Arrange
                 IDToken token = new IDToken();
-
-                // Act
                 mapper.transformIDToken(token, mappingModel, session, userSession, clientSessionCtx);
-
-                // Assert
-                assertTrue(token.getOtherClaims().containsKey(TestConstants.TEST_CLAIM_NAME),
-                                "Claim 'custom_status' should be present in ID token");
+                assertTrue(token.getOtherClaims().containsKey(TestConstants.TEST_CLAIM_NAME));
         }
 
         @Test
-        public void transformAccessToken_errorPath() {
-                // Arrange
+        public void transformAccessToken_errorPath_indexFails() {
                 doReturn(TestConstants.ERROR_INDEX).when(mapper).getNextIndex(session);
                 AccessToken token = new AccessToken();
 
-                // Act
                 mapper.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
 
-                // Assert
                 Map<String, Object> claims = token.getOtherClaims();
-                assertEquals(StatusListProtocolMapper.Constants.STATUS_ERROR_MESSAGE,
-                                claims.get(StatusListProtocolMapper.Constants.STATUS_ERROR_CLAIM),
-                                "Error claim should indicate index generation failure");
                 assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME),
-                                "Status claim should not be present on error");
+                                "Status claim should not be present on index error");
         }
 
         @Test
         public void defaultConfig_noClaimName() {
-                // Arrange
                 Map<String, String> configWithoutClaimName = new HashMap<>(Map.of(
                                 StatusListProtocolMapper.Constants.LIST_ID_PROPERTY, TestConstants.TEST_LIST_ID,
                                 OIDCAttributeMapperHelper.INCLUDE_IN_ACCESS_TOKEN, "true",
                                 OIDCAttributeMapperHelper.INCLUDE_IN_ID_TOKEN, "true"));
                 when(mappingModel.getConfig()).thenReturn(configWithoutClaimName);
-                AccessToken token = new AccessToken();
 
-                // Act
+                AccessToken token = new AccessToken();
                 mapper.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
 
-                // Assert
                 Map<String, Object> claims = token.getOtherClaims();
-                assertEquals(StatusListProtocolMapper.Constants.STATUS_ERROR_MESSAGE,
-                                claims.get(StatusListProtocolMapper.Constants.STATUS_ERROR_CLAIM),
-                                "Error claim should indicate missing claim name");
                 assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME),
                                 "Status claim should not be present when claim name is missing");
         }
 
         @Test
         public void statusListDisabled_shouldNotProcess() {
-                // Arrange
-                when(realm.getAttribute("status-list-enabled")).thenReturn("false");
-                AccessToken token = new AccessToken();
+                when(statusListConfig.isEnabled()).thenReturn(false);
 
-                // Act
+                AccessToken token = new AccessToken();
                 mapper.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
 
-                // Assert
                 Map<String, Object> claims = token.getOtherClaims();
-                assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME),
-                                "Status claim should not be present when status list is disabled");
-                assertFalse(claims.containsKey(StatusListProtocolMapper.Constants.STATUS_ERROR_CLAIM),
-                                "No error claim should be present when status list is disabled");
+                assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME));
         }
 
         @Test
-        public void invalidServerUrl_shouldAddErrorClaim() {
-                // Arrange
-                when(realm.getAttribute("status-list-server-url")).thenReturn("invalid-url");
-                AccessToken token = new AccessToken();
+        public void invalidServerUrl_shouldNotAddClaim() {
+                when(statusListConfig.getServerUrl()).thenReturn("invalid-url");
 
-                // Act
+                AccessToken token = new AccessToken();
                 mapper.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
 
-                // Assert
                 Map<String, Object> claims = token.getOtherClaims();
-                assertEquals("Invalid status list server URL",
-                                claims.get(StatusListProtocolMapper.Constants.STATUS_ERROR_CLAIM),
-                                "Error claim should indicate invalid server URL");
-                assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME),
-                                "Status claim should not be present when server URL is invalid");
+                assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME));
         }
 
         @Test
-        public void missingServerUrl_shouldAddErrorClaim() {
-                // Arrange
-                when(realm.getAttribute("status-list-server-url")).thenReturn("");
-                AccessToken token = new AccessToken();
+        public void missingServerUrl_shouldNotAddClaim() {
+                when(statusListConfig.getServerUrl()).thenReturn("");
 
-                // Act
+                AccessToken token = new AccessToken();
                 mapper.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
 
-                // Assert
                 Map<String, Object> claims = token.getOtherClaims();
-                assertEquals("Status list server URL not configured",
-                                claims.get(StatusListProtocolMapper.Constants.STATUS_ERROR_CLAIM),
-                                "Error claim should indicate missing server URL");
-                assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME),
-                                "Status claim should not be present when server URL is missing");
+                assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME));
         }
 
         @Test
-        public void nullServerUrl_shouldUseDefault() {
-                // Arrange
-                when(realm.getAttribute("status-list-server-url")).thenReturn(null);
-                AccessToken token = new AccessToken();
+        public void nullServerUrl_shouldNotAddClaim() {
+                when(statusListConfig.getServerUrl()).thenReturn(null);
 
-                // Act
+                AccessToken token = new AccessToken();
                 mapper.transformAccessToken(token, mappingModel, session, userSession, clientSessionCtx);
 
-                // Assert
                 Map<String, Object> claims = token.getOtherClaims();
-                assertTrue(claims.containsKey(TestConstants.TEST_CLAIM_NAME),
-                                "Status claim should be present when server URL is null (uses default)");
-                assertFalse(claims.containsKey(StatusListProtocolMapper.Constants.STATUS_ERROR_CLAIM),
-                                "No error claim should be present when server URL is null (uses default)");
+                assertFalse(claims.containsKey(TestConstants.TEST_CLAIM_NAME));
         }
 }

--- a/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
@@ -44,7 +44,8 @@ public class StatusListProtocolMapperTest {
 
                         @Override
                         protected void storeIndexMapping(String statusListId, long idx, String userId, String tokenId,
-                                        KeycloakSession session, Map<String, String> mapperConfig, com.adorsys.keycloakstatuslist.config.StatusListConfig realmConfig) {
+                                        KeycloakSession session, Map<String, String> mapperConfig,
+                                        com.adorsys.keycloakstatuslist.config.StatusListConfig realmConfig) {
                                 // no-op
                         }
                 });
@@ -70,7 +71,7 @@ public class StatusListProtocolMapperTest {
 
                 when(context.getRealm()).thenReturn(realm);
                 when(realm.getId()).thenReturn(TestConstants.TEST_REALM_ID);
-                
+
                 // Mock realm attributes for StatusListConfig
                 when(realm.getAttribute("status-list-enabled")).thenReturn("true");
                 when(realm.getAttribute("status-list-server-url")).thenReturn(TestConstants.TEST_SERVER_URL);
@@ -131,9 +132,9 @@ public class StatusListProtocolMapperTest {
 
                 // Verify storeIndexMapping was called with correct parameters
                 verify(mapper, times(1)).storeIndexMapping(
-                        eq(TestConstants.TEST_LIST_ID), eq(TestConstants.TEST_INDEX), anyString(), isNull(), 
-                        eq(session), anyMap(), any(com.adorsys.keycloakstatuslist.config.StatusListConfig.class)
-                );
+                                eq(TestConstants.TEST_LIST_ID), eq(TestConstants.TEST_INDEX), anyString(), isNull(),
+                                eq(session), anyMap(),
+                                any(com.adorsys.keycloakstatuslist.config.StatusListConfig.class));
         }
 
         @Test


### PR DESCRIPTION
This PR updates the plugin to allow the status list server URL to be configured as a Keycloak realm attribute. If no attribute is set, it will fall back to the default `https://statuslist.eudi-adorsys.com`.