### PR TITLE
Support Proxy and CA configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,17 @@ jobs:
           echo "TAG=$TAG" >> "$GITHUB_OUTPUT"
           echo "VERSION=${TAG#v}" >> "$GITHUB_OUTPUT"
 
+      - name: Derive groupId from repository owner
+        id: groupid
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          GROUP_ID="io.github.${OWNER,,}"
+          echo "GROUP_ID=$GROUP_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Set groupId in pom.xml
+        run: |
+          sed -i "s|<groupId>io\.github\.adorsys-gis</groupId>|<groupId>${{ steps.groupid.outputs.GROUP_ID }}</groupId>|" pom.xml
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:

--- a/README.md
+++ b/README.md
@@ -23,18 +23,24 @@ The status list server should implement the OAuth 2.0 Status List pattern.
 
 The plugin can be configured at the realm level with the following properties:
 
-| Property                                        | Description                                                                                                               | Default Value                         |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| `status-list-enabled`                           | Enables or disables the status list service                                                                               | `true`                                |
+| Property                                        | Description                                                                                                               | Default Value                        |
+| ----------------------------------------------- |---------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `status-list-enabled`                           | Enables or disables the status list service                                                                               | `true`                               |
 | `status-list-server-url`                        | URL of the status list server                                                                                             | `https://statuslist.eudi-adorsys.com` |
-| `status-list-token-issuer-prefix`               | Prefix for building the Token Issuer ID                                                                                   | `Generated UUID`                      |
-| `status-list-issuance-timeout`                  | Timeout in milliseconds for **issuance** operations (runtime). Non-positive values disable circuit breaker                | `10000`                               |
-| `status-list-registration-timeout`              | Timeout in milliseconds for **background registration** operations                                                        | `30000`                               |
-| `status-list-registration-retries`              | Number of retries for background registration operations                                                                  | `1`                                   |
-| `status-list-registration-cooldown`             | Cooldown period in **milliseconds** between registration attempts for the same realm                                      | `60000`                               |
-| `status-list-circuit-breaker-failure-threshold` | Number of failures/timeouts before opening the circuit breaker                                                            | `5`                                   |
-| `status-list-mandatory`                         | If true, publication failures block issuance; if false, failures are logged and issuance continues without a status claim | `false`                               |
-| `status-list-max-entries`                       | Maximum number of entries to publish under the same status list                                                           | `10000`                               |
+| `status-list-token-issuer-prefix`               | Prefix for building the Token Issuer ID                                                                                   | `Generated UUID`                     |
+| `status-list-issuance-timeout`                  | Timeout in milliseconds for **issuance** operations (runtime). Non-positive values disable circuit breaker                | `10000`                              |
+| `status-list-registration-timeout`              | Timeout in milliseconds for **background registration** operations                                                        | `30000`                              |
+| `status-list-registration-retries`              | Number of retries for background registration operations                                                                  | `1`                                  |
+| `status-list-registration-cooldown`             | Cooldown period in **milliseconds** between registration attempts for the same realm                                      | `60000`                              |
+| `status-list-circuit-breaker-failure-threshold` | Number of failures/timeouts before opening the circuit breaker                                                            | `5`                                  |
+| `status-list-mandatory`                         | If true, publication failures block issuance; if false, failures are logged and issuance continues without a status claim | `false`                              |
+| `status-list-max-entries`                       | Maximum number of entries to publish under the same status list                                                           | `10000`                              |
+| `status-list-tls-trust-all`                     | Instructs the status-list-server http-client to trust all ssl-certificates. **DO NOT USE IN PRODUCTION**                  | `false`                              |
+| `status-list-tls-ca-cert-path`                  | Path to an additional tls-ca file to be trusted by the status-list-server http-client                                     | `false`                              |
+
+### Proxy support
+
+Usage of HTTP/S-Proxies for the Status-List-Client is supported through the standard Keycloak-Proxy Environment Variables: [Keycloak Outgoing Proxy Config](https://www.keycloak.org/server/outgoinghttp#_proxy_mappings_for_outgoing_http_requests)
 
 ## Compatibility
 

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -1,0 +1,367 @@
+openapi: 3.0.3
+info:
+  title: Token Status List Keycloak Plugin API
+  description: >
+    REST API endpoints added by the Token Status List Keycloak plugin.
+    This plugin enables credential status management using the Token Status List
+    specification (draft-ietf-oauth-status-list). It provides holder-initiated
+    revocation via SD-JWT VP as well as issuer-side admin endpoints for querying
+    and updating credential status.
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: "{keycloakBaseUrl}/realms/{realm}"
+    description: Keycloak realm base URL
+    variables:
+      keycloakBaseUrl:
+        default: http://localhost:8080
+        description: Base URL of the Keycloak instance
+      realm:
+        default: master
+        description: Name of the Keycloak realm
+
+paths:
+  /protocol/openid-connect/revoke/challenge:
+    get:
+      tags:
+        - Holder Revocation
+      summary: Get a revocation challenge
+      description: >
+        Issues a nonce challenge for credential revocation. This is the first
+        step of the two-step holder-initiated revocation flow. The returned
+        nonce must be included in the SD-JWT VP presented to the revocation
+        endpoint.
+      operationId: getRevocationChallenge
+      responses:
+        "200":
+          description: Challenge issued successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RevocationChallenge"
+        "500":
+          description: Nonce service unavailable or internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+  /protocol/openid-connect/revoke:
+    post:
+      tags:
+        - Holder Revocation
+      summary: Revoke a credential (holder-initiated)
+      description: >
+        Revokes a credential using an SD-JWT Verifiable Presentation. The holder
+        presents their credential as a Bearer token in the Authorization header.
+        The presentation must include a valid nonce obtained from the challenge
+        endpoint. When mode is not set to `credential_revocation`, the request
+        falls through to Keycloak's standard token revocation endpoint.
+      operationId: revokeCredential
+      parameters:
+        - name: Authorization
+          in: header
+          required: true
+          description: "Bearer token containing the SD-JWT Verifiable Presentation"
+          schema:
+            type: string
+            example: "Bearer <SD-JWT-VP>"
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              required:
+                - mode
+              properties:
+                mode:
+                  type: string
+                  description: Must be `credential_revocation` to trigger credential revocation
+                  enum:
+                    - credential_revocation
+                reason:
+                  type: string
+                  description: Optional reason for the revocation
+      responses:
+        "200":
+          description: Credential revoked successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialRevocationResponse"
+        "400":
+          description: Invalid authorization header format or invalid input
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialRevocationResponse"
+        "401":
+          description: Missing Authorization header
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialRevocationResponse"
+        "500":
+          description: Service disabled, not configured, or internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialRevocationResponse"
+
+  /status-list-admin:
+    get:
+      tags:
+        - Admin
+      summary: List credential status entries
+      description: >
+        Returns a paginated list of credential status entries for the current
+        realm. Requires a Bearer token from a user with the `realm-admin` role
+        on the `realm-management` client.
+      operationId: getCredentialStatuses
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: offset
+          in: query
+          description: Zero-based pagination offset
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+        - name: limit
+          in: query
+          description: Maximum number of entries to return (capped at 100)
+          required: false
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        "200":
+          description: Paginated list of credential status entries
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialStatusPage"
+        "401":
+          description: Missing or invalid Bearer token
+        "403":
+          description: Authenticated user does not have the realm-admin role
+
+  /status-list-admin/{id}:
+    put:
+      tags:
+        - Admin
+      summary: Update credential status
+      description: >
+        Updates the status of a credential on the external status list server.
+        The credential is identified by its internal mapping ID (as returned by
+        the GET endpoint). Requires a Bearer token from a user with the
+        `realm-admin` role on the `realm-management` client.
+      operationId: updateCredentialStatus
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Primary key of the status list mapping entry
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CredentialStatusUpdateRequest"
+      responses:
+        "200":
+          description: Status updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialStatusResponse"
+        "400":
+          description: Missing or invalid status value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: Missing or invalid Bearer token
+        "403":
+          description: Authenticated user does not have the realm-admin role
+        "404":
+          description: Credential mapping not found in the current realm
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "502":
+          description: Failed to update status on the external status list server
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: >
+        Keycloak access token for a user with the `realm-admin` role on the
+        `realm-management` client.
+
+  schemas:
+    RevocationChallenge:
+      type: object
+      description: Challenge response for the holder-initiated revocation flow
+      properties:
+        nonce:
+          type: string
+          description: One-time nonce to include in the SD-JWT VP
+        aud:
+          type: string
+          description: Expected audience (the revocation endpoint URL)
+        exp:
+          type: integer
+          format: int64
+          description: Expiration time as Unix epoch seconds
+        expires_in:
+          type: integer
+          description: Seconds until the challenge expires (deprecated, use `exp`)
+          deprecated: true
+      required:
+        - nonce
+        - aud
+        - exp
+        - expires_in
+
+    CredentialRevocationResponse:
+      type: object
+      description: Result of a credential revocation attempt
+      properties:
+        success:
+          type: boolean
+          description: Whether the revocation was successful
+        revoked_at:
+          type: string
+          format: date-time
+          description: Timestamp when the credential was revoked (null on failure)
+          nullable: true
+        revocation_reason:
+          type: string
+          description: Reason provided for the revocation (null on failure)
+          nullable: true
+        message:
+          type: string
+          description: Human-readable result message
+      required:
+        - success
+
+    CredentialStatusPage:
+      type: object
+      description: Paginated list of credential status entries
+      properties:
+        items:
+          type: array
+          description: Credential status entries for the current page
+          items:
+            $ref: "#/components/schemas/CredentialStatusResponse"
+        total:
+          type: integer
+          format: int64
+          description: Total number of credential status entries in the realm
+        offset:
+          type: integer
+          description: Zero-based offset used for this page
+        limit:
+          type: integer
+          description: Maximum number of entries per page
+      required:
+        - items
+        - total
+        - offset
+        - limit
+
+    CredentialStatusResponse:
+      type: object
+      description: A single credential's status list mapping entry
+      properties:
+        id:
+          type: string
+          description: Internal mapping entry ID
+        token_id:
+          type: string
+          description: Token identifier of the issued credential
+        user_id:
+          type: string
+          description: Keycloak user ID of the credential holder
+        username:
+          type: string
+          description: Username of the credential holder
+          nullable: true
+        status:
+          type: string
+          description: Current token status
+          enum:
+            - VALID
+            - INVALID
+        status_list_id:
+          type: string
+          description: Identifier of the status list this credential belongs to
+        index:
+          type: integer
+          format: int64
+          description: Index position within the status list
+        created_timestamp:
+          type: integer
+          format: int64
+          description: Creation time as Unix epoch milliseconds
+        metadata:
+          type: object
+          description: >
+            Arbitrary metadata extracted from credential claims at issuance time
+            (configured via the StatusListProtocolMapper). Structure depends on
+            the configured claim paths.
+          nullable: true
+          additionalProperties: true
+      required:
+        - id
+        - token_id
+        - user_id
+        - status
+        - status_list_id
+        - index
+        - created_timestamp
+
+    CredentialStatusUpdateRequest:
+      type: object
+      description: Request to update a credential's status
+      properties:
+        status:
+          type: string
+          description: New status value
+          enum:
+            - VALID
+            - INVALID
+      required:
+        - status
+
+    ErrorResponse:
+      type: object
+      description: Generic error response
+      properties:
+        error:
+          type: string
+          description: Error message
+      required:
+        - error

--- a/open-api.yaml
+++ b/open-api.yaml
@@ -119,7 +119,8 @@ paths:
       summary: List credential status entries
       description: >
         Returns a paginated list of credential status entries for the current
-        realm. Requires a Bearer token from a user with the `realm-admin` role
+        realm, optionally filtered by username, token status, and metadata
+        claims. Requires a Bearer token from a user with the `realm-admin` role
         on the `realm-management` client.
       operationId: getCredentialStatuses
       security:
@@ -142,6 +143,44 @@ paths:
             default: 20
             minimum: 1
             maximum: 100
+        - name: username
+          in: query
+          description: >
+            Filter by exact username. The username is resolved to a user ID
+            internally. If no user with the given username exists, an empty
+            result set is returned.
+          required: false
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Filter by token status
+          required: false
+          schema:
+            type: string
+            enum:
+              - VALID
+              - INVALID
+        - name: claims
+          in: query
+          description: >
+            Filter by metadata content (substring match). Can be repeated to
+            require multiple matches (AND logic). Each value is matched against
+            the JSON metadata stored at issuance time.
+          required: false
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+          examples:
+            singleClaim:
+              summary: Filter by credential type
+              value: ["IdentityCredential"]
+            multipleClaims:
+              summary: Filter by type and country
+              value: ["IdentityCredential", "DE"]
       responses:
         "200":
           description: Paginated list of credential status entries
@@ -149,6 +188,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CredentialStatusPage"
+        "400":
+          description: Invalid status filter value
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: Missing or invalid Bearer token
         "403":

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <url>https://github.com/ADORSYS-GIS/token-status-link</url>
 
     <properties>
-        <revision>1.0.0-SNAPSHOT</revision>
+        <revision>0.3.0</revision>
         <keycloak.version>26.6.3</keycloak.version>
         <jackson.version>2.19.2</jackson.version>
         <mockito.version>5.20.0</mockito.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <!-- TODO: Update package hierarchy in the codebase to match this groupId.
           Delayed to avoid giant conflicts given ongoing PRs. -->
-    <groupId>io.github.adorsys-gis</groupId>
+    <groupId>io.github.wistefan</groupId>
     <artifactId>keycloak-token-status-plugin</artifactId>
     <version>${revision}</version>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <!-- TODO: Update package hierarchy in the codebase to match this groupId.
           Delayed to avoid giant conflicts given ongoing PRs. -->
-    <groupId>io.github.wistefan</groupId>
+    <groupId>io.github.adorsys-gis</groupId>
     <artifactId>keycloak-token-status-plugin</artifactId>
     <version>${revision}</version>
     <packaging>jar</packaging>
@@ -14,7 +14,7 @@
     <url>https://github.com/ADORSYS-GIS/token-status-link</url>
 
     <properties>
-        <revision>0.3.0</revision>
+        <revision>1.0.0-SNAPSHOT</revision>
         <keycloak.version>26.6.3</keycloak.version>
         <jackson.version>2.19.2</jackson.version>
         <mockito.version>5.20.0</mockito.version>
@@ -86,6 +86,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>5.12.2</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
@@ -76,6 +76,14 @@ public class StatusListProtocolMapper extends OID4VCMapper {
     private final StatusListService statusListService;
     private final StatusListRepository statusListRepository;
 
+    /**
+     * Holds the mapping entity persisted during {@link #setClaim(Map, UserSessionModel)}
+     * so that metadata can be extracted and attached later in
+     * {@link #setClaim(VerifiableCredential, UserSessionModel)} when all credential
+     * claims are fully populated.
+     */
+    private StatusListMappingEntity pendingMappingEntity;
+
     public StatusListProtocolMapper() {
         // An empty mapper constructor is required by Keycloak
         this.session = null;
@@ -160,7 +168,25 @@ public class StatusListProtocolMapper extends OID4VCMapper {
 
     @Override
     public void setClaim(VerifiableCredential verifiableCredential, UserSessionModel userSessionModel) {
-        // No-op. W3C Verifiable Credentials are not supported by this mapper.
+        if (pendingMappingEntity == null) {
+            return;
+        }
+
+        Map<String, Object> claims = verifiableCredential.getCredentialSubject().getClaims();
+        List<String> credentialTypes = isIncludeCredentialTypes() ? findCredentialTypes() : List.of();
+        String metadata = extractMetadata(claims, credentialTypes);
+
+        if (metadata != null) {
+            pendingMappingEntity.setMetadata(metadata);
+            try {
+                statusListRepository.withEntityManagerInTransaction(
+                        em -> em.merge(pendingMappingEntity));
+            } catch (Exception e) {
+                logger.error("Failed to persist metadata for status list mapping", e);
+            }
+        }
+
+        pendingMappingEntity = null;
     }
 
     @Override
@@ -206,9 +232,9 @@ public class StatusListProtocolMapper extends OID4VCMapper {
         UserSessionModel userSession = session.getContext().getUserSession();
         String userId = userSession != null ? userSession.getUser().getId() : null;
 
-        List<String> credentialTypes = isIncludeCredentialTypes() ? findCredentialTypes() : List.of();
-        String metadata = extractMetadata(claims, credentialTypes);
-        Status status = sendStatusAndStoreIndexMapping(listId, uri.toString(), userId, tokenId, metadata);
+        StatusListMappingEntity mappingEntity = new StatusListMappingEntity();
+        Status status = sendStatusAndStoreIndexMapping(
+                listId, uri.toString(), userId, tokenId, null, mappingEntity);
 
         if (status == null) {
             if (config.isMandatory()) {
@@ -220,6 +246,7 @@ public class StatusListProtocolMapper extends OID4VCMapper {
             return;
         }
 
+        pendingMappingEntity = mappingEntity;
         logger.infof("Adding status claim of value: %s", status);
         claims.put(Constants.STATUS_CLAIM_KEY, status);
     }
@@ -247,7 +274,24 @@ public class StatusListProtocolMapper extends OID4VCMapper {
      */
     public Status sendStatusAndStoreIndexMapping(
             String statusListId, String uri, String userId, String tokenId, String metadata) {
-        StatusListMappingEntity mapping = new StatusListMappingEntity();
+        return sendStatusAndStoreIndexMapping(
+                statusListId, uri, userId, tokenId, metadata, new StatusListMappingEntity());
+    }
+
+    /**
+     * Send status to server to create status list entry and store index mapping in database.
+     *
+     * @param statusListId the status list identifier
+     * @param uri the status list URI
+     * @param userId the user ID of the credential holder
+     * @param tokenId the credential/token identifier
+     * @param metadata JSON string of extracted claim metadata, or null if no metadata configured
+     * @param mapping the entity to persist for this mapping
+     * @return the Status claim to embed in the credential, or null on failure
+     */
+    public Status sendStatusAndStoreIndexMapping(
+            String statusListId, String uri, String userId, String tokenId, String metadata,
+            StatusListMappingEntity mapping) {
         mapping.setStatusListId(statusListId);
         mapping.setUserId(userId);
         mapping.setTokenId(tokenId);

--- a/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
@@ -15,11 +15,15 @@ import com.adorsys.keycloakstatuslist.service.CircuitBreaker;
 import com.adorsys.keycloakstatuslist.service.CryptoIdentityService;
 import com.adorsys.keycloakstatuslist.service.CustomHttpClient;
 import com.adorsys.keycloakstatuslist.service.StatusListService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.ws.rs.core.UriBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.collections4.ListUtils;
@@ -42,7 +46,20 @@ import org.keycloak.provider.ProviderConfigProperty;
 public class StatusListProtocolMapper extends OID4VCMapper {
 
     private static final Logger logger = Logger.getLogger(StatusListProtocolMapper.class);
+    private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
     private static final List<ProviderConfigProperty> CONFIG_PROPERTIES = new ArrayList<>();
+
+    static {
+        ProviderConfigProperty metadataClaimPaths = new ProviderConfigProperty();
+        metadataClaimPaths.setName(Constants.METADATA_CLAIM_PATHS_KEY);
+        metadataClaimPaths.setLabel("Metadata Claim Paths");
+        metadataClaimPaths.setHelpText(
+                "Comma-separated list of claim paths to extract from the issued credential "
+                        + "and store as metadata (e.g. 'vct,sub.email'). "
+                        + "Nested claims use dot notation.");
+        metadataClaimPaths.setType(ProviderConfigProperty.STRING_TYPE);
+        CONFIG_PROPERTIES.add(metadataClaimPaths);
+    }
 
     private final KeycloakSession session;
     private final StatusListService statusListService;
@@ -178,7 +195,8 @@ public class StatusListProtocolMapper extends OID4VCMapper {
         UserSessionModel userSession = session.getContext().getUserSession();
         String userId = userSession != null ? userSession.getUser().getId() : null;
 
-        Status status = sendStatusAndStoreIndexMapping(listId, uri.toString(), userId, tokenId);
+        String metadata = extractMetadata(claims);
+        Status status = sendStatusAndStoreIndexMapping(listId, uri.toString(), userId, tokenId, metadata);
 
         if (status == null) {
             if (config.isMandatory()) {
@@ -207,13 +225,22 @@ public class StatusListProtocolMapper extends OID4VCMapper {
 
     /**
      * Send status to server to create status list entry and store index mapping in database.
+     *
+     * @param statusListId the status list identifier
+     * @param uri the status list URI
+     * @param userId the user ID of the credential holder
+     * @param tokenId the credential/token identifier
+     * @param metadata JSON string of extracted claim metadata, or null if no metadata configured
+     * @return the Status claim to embed in the credential, or null on failure
      */
-    public Status sendStatusAndStoreIndexMapping(String statusListId, String uri, String userId, String tokenId) {
+    public Status sendStatusAndStoreIndexMapping(
+            String statusListId, String uri, String userId, String tokenId, String metadata) {
         StatusListMappingEntity mapping = new StatusListMappingEntity();
         mapping.setStatusListId(statusListId);
         mapping.setUserId(userId);
         mapping.setTokenId(tokenId);
         mapping.setRealmId(session.getContext().getRealm().getId());
+        mapping.setMetadata(metadata);
 
         try {
             logger.debugf(
@@ -259,6 +286,67 @@ public class StatusListProtocolMapper extends OID4VCMapper {
         return status;
     }
 
+    /**
+     * Extracts configured claim values from the credential claims and serializes them as a JSON string.
+     *
+     * @param claims the credential claims map
+     * @return JSON string of extracted metadata, or null if no claim paths are configured
+     */
+    String extractMetadata(Map<String, Object> claims) {
+        if (mapperModel == null) {
+            return null;
+        }
+        String claimPathsConfig = mapperModel.getConfig().get(Constants.METADATA_CLAIM_PATHS_KEY);
+        if (claimPathsConfig == null || claimPathsConfig.isBlank()) {
+            return null;
+        }
+
+        List<String> paths = Arrays.stream(claimPathsConfig.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+
+        Map<String, Object> metadata = new LinkedHashMap<>();
+        for (String path : paths) {
+            Object value = resolveClaimPath(claims, path);
+            if (value != null) {
+                metadata.put(path, value);
+            }
+        }
+
+        if (metadata.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return JSON_MAPPER.writeValueAsString(metadata);
+        } catch (JsonProcessingException e) {
+            logger.warnf("Failed to serialize metadata for claim paths [%s]: %s", claimPathsConfig, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Resolves a dot-separated claim path against a nested map structure.
+     *
+     * @param claims the root claims map
+     * @param path dot-separated path (e.g. "sub.email")
+     * @return the resolved value, or null if any segment is missing or not a map
+     */
+    @SuppressWarnings("unchecked")
+    static Object resolveClaimPath(Map<String, Object> claims, String path) {
+        String[] segments = path.split("\\.");
+        Object current = claims;
+        for (String segment : segments) {
+            if (current instanceof Map<?, ?> map) {
+                current = map.get(segment);
+            } else {
+                return null;
+            }
+        }
+        return current;
+    }
+
     private void sendStatusToServer(long idx, String statusListId) throws IOException, StatusListException {
         // Prepare payload
         StatusListService.StatusListPayload payload = new StatusListService.StatusListPayload(
@@ -274,6 +362,7 @@ public class StatusListProtocolMapper extends OID4VCMapper {
 
         String ID_CLAIM_KEY = "id";
         String STATUS_CLAIM_KEY = "status";
+        String METADATA_CLAIM_PATHS_KEY = "metadata.claim.paths";
 
         String HTTP_ENDPOINT_RETRIEVE_PATH = "/statuslists/%s";
     }

--- a/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapper.java
@@ -31,6 +31,7 @@ import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserSessionModel;
+import org.keycloak.models.oid4vci.CredentialScopeModel;
 import org.keycloak.protocol.ProtocolMapper;
 import org.keycloak.protocol.oid4vc.issuance.mappers.OID4VCMapper;
 import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
@@ -59,6 +60,16 @@ public class StatusListProtocolMapper extends OID4VCMapper {
                         + "Nested claims use dot notation.");
         metadataClaimPaths.setType(ProviderConfigProperty.STRING_TYPE);
         CONFIG_PROPERTIES.add(metadataClaimPaths);
+
+        ProviderConfigProperty includeCredentialTypes = new ProviderConfigProperty();
+        includeCredentialTypes.setName(Constants.INCLUDE_CREDENTIAL_TYPES_KEY);
+        includeCredentialTypes.setLabel("Include Credential Types");
+        includeCredentialTypes.setHelpText(
+                "When enabled, includes the credential types from the parent credential scope "
+                        + "in the stored metadata under the 'type' key.");
+        includeCredentialTypes.setType(ProviderConfigProperty.BOOLEAN_TYPE);
+        includeCredentialTypes.setDefaultValue(Constants.INCLUDE_CREDENTIAL_TYPES_DEFAULT);
+        CONFIG_PROPERTIES.add(includeCredentialTypes);
     }
 
     private final KeycloakSession session;
@@ -195,7 +206,8 @@ public class StatusListProtocolMapper extends OID4VCMapper {
         UserSessionModel userSession = session.getContext().getUserSession();
         String userId = userSession != null ? userSession.getUser().getId() : null;
 
-        String metadata = extractMetadata(claims);
+        List<String> credentialTypes = isIncludeCredentialTypes() ? findCredentialTypes() : List.of();
+        String metadata = extractMetadata(claims, credentialTypes);
         Status status = sendStatusAndStoreIndexMapping(listId, uri.toString(), userId, tokenId, metadata);
 
         if (status == null) {
@@ -290,28 +302,42 @@ public class StatusListProtocolMapper extends OID4VCMapper {
      * Extracts configured claim values from the credential claims and serializes them as a JSON string.
      *
      * @param claims the credential claims map
-     * @return JSON string of extracted metadata, or null if no claim paths are configured
+     * @return JSON string of extracted metadata, or null if no metadata is available
      */
     String extractMetadata(Map<String, Object> claims) {
-        if (mapperModel == null) {
-            return null;
-        }
-        String claimPathsConfig = mapperModel.getConfig().get(Constants.METADATA_CLAIM_PATHS_KEY);
-        if (claimPathsConfig == null || claimPathsConfig.isBlank()) {
-            return null;
-        }
+        return extractMetadata(claims, List.of());
+    }
 
-        List<String> paths = Arrays.stream(claimPathsConfig.split(","))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .toList();
-
+    /**
+     * Extracts configured claim values from the credential claims, optionally including
+     * credential types, and serializes them as a JSON string.
+     *
+     * @param claims          the credential claims map
+     * @param credentialTypes credential types from the parent scope to include under the "type" key
+     * @return JSON string of extracted metadata, or null if no metadata is available
+     */
+    String extractMetadata(Map<String, Object> claims, List<String> credentialTypes) {
         Map<String, Object> metadata = new LinkedHashMap<>();
-        for (String path : paths) {
-            Object value = resolveClaimPath(claims, path);
-            if (value != null) {
-                metadata.put(path, value);
+
+        if (mapperModel != null) {
+            String claimPathsConfig = mapperModel.getConfig().get(Constants.METADATA_CLAIM_PATHS_KEY);
+            if (claimPathsConfig != null && !claimPathsConfig.isBlank()) {
+                List<String> paths = Arrays.stream(claimPathsConfig.split(","))
+                        .map(String::trim)
+                        .filter(s -> !s.isEmpty())
+                        .toList();
+
+                for (String path : paths) {
+                    Object value = resolveClaimPath(claims, path);
+                    if (value != null) {
+                        metadata.put(path, value);
+                    }
+                }
             }
+        }
+
+        if (credentialTypes != null && !credentialTypes.isEmpty()) {
+            metadata.put(Constants.CREDENTIAL_TYPES_METADATA_KEY, credentialTypes);
         }
 
         if (metadata.isEmpty()) {
@@ -321,9 +347,46 @@ public class StatusListProtocolMapper extends OID4VCMapper {
         try {
             return JSON_MAPPER.writeValueAsString(metadata);
         } catch (JsonProcessingException e) {
-            logger.warnf("Failed to serialize metadata for claim paths [%s]: %s", claimPathsConfig, e.getMessage());
+            logger.warnf("Failed to serialize metadata: %s", e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Checks whether the credential types inclusion flag is enabled in the mapper configuration.
+     * Defaults to true if not explicitly configured.
+     *
+     * @return true if credential types should be included in metadata
+     */
+    private boolean isIncludeCredentialTypes() {
+        if (mapperModel == null) {
+            return true;
+        }
+        String value = mapperModel.getConfig().get(Constants.INCLUDE_CREDENTIAL_TYPES_KEY);
+        return value == null || Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Finds the credential types configured on the parent credential scope of this mapper
+     * by searching all client scopes in the realm for one containing this mapper.
+     *
+     * @return the supported credential types, or an empty list if the scope cannot be found
+     */
+    List<String> findCredentialTypes() {
+        if (session == null || mapperModel == null) {
+            return List.of();
+        }
+        String mapperId = mapperModel.getId();
+        if (mapperId == null) {
+            return List.of();
+        }
+        return session.getContext().getRealm()
+                .getClientScopesStream()
+                .filter(cs -> cs.getProtocolMapperById(mapperId) != null)
+                .map(CredentialScopeModel::new)
+                .findFirst()
+                .map(CredentialScopeModel::getSupportedCredentialTypes)
+                .orElse(List.of());
     }
 
     /**
@@ -363,6 +426,9 @@ public class StatusListProtocolMapper extends OID4VCMapper {
         String ID_CLAIM_KEY = "id";
         String STATUS_CLAIM_KEY = "status";
         String METADATA_CLAIM_PATHS_KEY = "metadata.claim.paths";
+        String INCLUDE_CREDENTIAL_TYPES_KEY = "include.credential.types";
+        String INCLUDE_CREDENTIAL_TYPES_DEFAULT = "true";
+        String CREDENTIAL_TYPES_METADATA_KEY = "type";
 
         String HTTP_ENDPOINT_RETRIEVE_PATH = "/statuslists/%s";
     }

--- a/src/main/java/com/adorsys/keycloakstatuslist/config/StatusListConfig.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/config/StatusListConfig.java
@@ -25,6 +25,8 @@ public class StatusListConfig {
             "status-list-circuit-breaker-failure-threshold";
     public static final String STATUS_LIST_MANDATORY = "status-list-mandatory";
     public static final String STATUS_LIST_MAX_ENTRIES = "status-list-max-entries";
+    public static final String STATUS_LIST_TLS_TRUST_ALL = "status-list-tls-trust-all";
+    public static final String STATUS_LIST_TLS_CA_CERT_PATH = "status-list-tls-ca-cert-path";
 
     // Default values
     public static final boolean DEFAULT_ENABLED = true;
@@ -178,6 +180,25 @@ public class StatusListConfig {
      */
     public int getCircuitBreakerCooldownSeconds() {
         return DEFAULT_COOLDOWN_SECONDS;
+    }
+
+    /**
+     * Checks if TLS certificate verification should be skipped for the status list server.
+     *
+     * @return true if all certificates should be trusted, false otherwise
+     */
+    public boolean isTlsTrustAll() {
+        String value = realm.getAttribute(STATUS_LIST_TLS_TRUST_ALL);
+        return value != null && Boolean.parseBoolean(value);
+    }
+
+    /**
+     * Gets the path to a PEM-encoded CA certificate file for verifying the status list server's TLS certificate.
+     *
+     * @return the CA certificate file path, or null if not configured
+     */
+    public String getTlsCaCertPath() {
+        return realm.getAttribute(STATUS_LIST_TLS_CA_CERT_PATH);
     }
 
     /**

--- a/src/main/java/com/adorsys/keycloakstatuslist/jpa/entity/StatusListMappingEntity.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/jpa/entity/StatusListMappingEntity.java
@@ -1,5 +1,6 @@
 package com.adorsys.keycloakstatuslist.jpa.entity;
 
+import com.adorsys.keycloakstatuslist.model.TokenStatus;
 import jakarta.persistence.Access;
 import jakarta.persistence.AccessType;
 import jakarta.persistence.Column;
@@ -45,6 +46,10 @@ public class StatusListMappingEntity {
 
     @Column(name = "created_timestamp", nullable = false, updatable = false)
     private final Long createdTimestamp = Time.currentTimeMillis();
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "token_status")
+    private TokenStatus tokenStatus = TokenStatus.VALID;
 
     @Column(name = "metadata", columnDefinition = "clob")
     private String metadata;
@@ -112,6 +117,14 @@ public class StatusListMappingEntity {
         return createdTimestamp;
     }
 
+    public TokenStatus getTokenStatus() {
+        return tokenStatus;
+    }
+
+    public void setTokenStatus(TokenStatus tokenStatus) {
+        this.tokenStatus = tokenStatus;
+    }
+
     public String getMetadata() {
         return metadata;
     }
@@ -131,6 +144,7 @@ public class StatusListMappingEntity {
                 && Objects.equals(getTokenId(), that.getTokenId())
                 && Objects.equals(getRealmId(), that.getRealmId())
                 && getStatus() == that.getStatus()
+                && getTokenStatus() == that.getTokenStatus()
                 && Objects.equals(getCreatedTimestamp(), that.getCreatedTimestamp())
                 && Objects.equals(getMetadata(), that.getMetadata());
     }
@@ -145,6 +159,7 @@ public class StatusListMappingEntity {
                 getTokenId(),
                 getRealmId(),
                 getStatus(),
+                getTokenStatus(),
                 getCreatedTimestamp(),
                 getMetadata());
     }

--- a/src/main/java/com/adorsys/keycloakstatuslist/jpa/entity/StatusListMappingEntity.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/jpa/entity/StatusListMappingEntity.java
@@ -46,6 +46,9 @@ public class StatusListMappingEntity {
     @Column(name = "created_timestamp", nullable = false, updatable = false)
     private final Long createdTimestamp = Time.currentTimeMillis();
 
+    @Column(name = "metadata", columnDefinition = "clob")
+    private String metadata;
+
     // --- Getters and Setters ---
 
     public String getId() {
@@ -109,6 +112,14 @@ public class StatusListMappingEntity {
         return createdTimestamp;
     }
 
+    public String getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(String metadata) {
+        this.metadata = metadata;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) return false;
@@ -120,7 +131,8 @@ public class StatusListMappingEntity {
                 && Objects.equals(getTokenId(), that.getTokenId())
                 && Objects.equals(getRealmId(), that.getRealmId())
                 && getStatus() == that.getStatus()
-                && Objects.equals(getCreatedTimestamp(), that.getCreatedTimestamp());
+                && Objects.equals(getCreatedTimestamp(), that.getCreatedTimestamp())
+                && Objects.equals(getMetadata(), that.getMetadata());
     }
 
     @Override
@@ -133,7 +145,8 @@ public class StatusListMappingEntity {
                 getTokenId(),
                 getRealmId(),
                 getStatus(),
-                getCreatedTimestamp());
+                getCreatedTimestamp(),
+                getMetadata());
     }
 
     public enum MappingStatus {

--- a/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
@@ -92,6 +92,15 @@ public class StatusListRepository {
     }
 
     /**
+     * Merges the given entity into the persistence context within a transaction.
+     *
+     * @param entity the entity to update
+     */
+    public void updateMapping(StatusListMappingEntity entity) {
+        withEntityManagerInTransaction(em -> em.merge(entity));
+    }
+
+    /**
      * Returns a paginated list of status list mappings for the given realm, ordered by creation time descending.
      *
      * @param realmId the realm identifier

--- a/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
@@ -4,6 +4,7 @@ import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -72,6 +73,59 @@ public class StatusListRepository {
         }
 
         return latest.getStatusListId();
+    }
+
+    /**
+     * Returns a paginated list of status list mappings for the given realm, ordered by creation time descending.
+     *
+     * @param realmId the realm identifier
+     * @param offset zero-based offset for pagination
+     * @param limit maximum number of results to return
+     * @return list of matching entities, or empty list if none found
+     */
+    public List<StatusListMappingEntity> getMappings(String realmId, int offset, int limit) {
+        AtomicReference<List<StatusListMappingEntity>> result = new AtomicReference<>(Collections.emptyList());
+
+        withEntityManagerInTransaction(em -> {
+            String q = """
+                        SELECT m FROM StatusListMappingEntity m
+                        WHERE m.realmId = :realmId
+                        ORDER BY m.createdTimestamp DESC
+                    """;
+
+            TypedQuery<StatusListMappingEntity> query = em.createQuery(q, StatusListMappingEntity.class);
+            query.setParameter("realmId", realmId);
+            query.setFirstResult(offset);
+            query.setMaxResults(limit);
+
+            result.set(query.getResultList());
+        });
+
+        return result.get();
+    }
+
+    /**
+     * Returns the total number of status list mappings for the given realm.
+     *
+     * @param realmId the realm identifier
+     * @return total count of mappings
+     */
+    public long countMappings(String realmId) {
+        AtomicReference<Long> result = new AtomicReference<>(0L);
+
+        withEntityManagerInTransaction(em -> {
+            String q = """
+                        SELECT COUNT(m) FROM StatusListMappingEntity m
+                        WHERE m.realmId = :realmId
+                    """;
+
+            TypedQuery<Long> query = em.createQuery(q, Long.class);
+            query.setParameter("realmId", realmId);
+
+            result.set(query.getSingleResult());
+        });
+
+        return result.get();
     }
 
     /**

--- a/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
@@ -76,6 +76,22 @@ public class StatusListRepository {
     }
 
     /**
+     * Finds a status list mapping by its primary key ID.
+     *
+     * @param id the entity's primary key
+     * @return the entity, or null if not found
+     */
+    public StatusListMappingEntity findById(String id) {
+        AtomicReference<StatusListMappingEntity> result = new AtomicReference<>();
+
+        withEntityManagerInTransaction(em -> {
+            result.set(em.find(StatusListMappingEntity.class, id));
+        });
+
+        return result.get();
+    }
+
+    /**
      * Returns a paginated list of status list mappings for the given realm, ordered by creation time descending.
      *
      * @param realmId the realm identifier

--- a/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/jpa/repository/StatusListRepository.java
@@ -1,6 +1,7 @@
 package com.adorsys.keycloakstatuslist.jpa.repository;
 
 import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusFilter;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.TypedQuery;
@@ -104,22 +105,24 @@ public class StatusListRepository {
      * Returns a paginated list of status list mappings for the given realm, ordered by creation time descending.
      *
      * @param realmId the realm identifier
-     * @param offset zero-based offset for pagination
-     * @param limit maximum number of results to return
+     * @param filter  optional filter criteria
+     * @param offset  zero-based offset for pagination
+     * @param limit   maximum number of results to return
      * @return list of matching entities, or empty list if none found
      */
-    public List<StatusListMappingEntity> getMappings(String realmId, int offset, int limit) {
+    public List<StatusListMappingEntity> getMappings(
+            String realmId, CredentialStatusFilter filter, int offset, int limit) {
         AtomicReference<List<StatusListMappingEntity>> result = new AtomicReference<>(Collections.emptyList());
 
         withEntityManagerInTransaction(em -> {
-            String q = """
-                        SELECT m FROM StatusListMappingEntity m
-                        WHERE m.realmId = :realmId
-                        ORDER BY m.createdTimestamp DESC
-                    """;
+            StringBuilder jpql = new StringBuilder(
+                    "SELECT m FROM StatusListMappingEntity m WHERE m.realmId = :realmId");
+            appendFilterClauses(jpql, filter);
+            jpql.append(" ORDER BY m.createdTimestamp DESC");
 
-            TypedQuery<StatusListMappingEntity> query = em.createQuery(q, StatusListMappingEntity.class);
+            TypedQuery<StatusListMappingEntity> query = em.createQuery(jpql.toString(), StatusListMappingEntity.class);
             query.setParameter("realmId", realmId);
+            setFilterParameters(query, filter);
             query.setFirstResult(offset);
             query.setMaxResults(limit);
 
@@ -130,27 +133,62 @@ public class StatusListRepository {
     }
 
     /**
-     * Returns the total number of status list mappings for the given realm.
+     * Returns the total number of status list mappings for the given realm matching the filter.
      *
      * @param realmId the realm identifier
-     * @return total count of mappings
+     * @param filter  optional filter criteria
+     * @return total count of matching mappings
      */
-    public long countMappings(String realmId) {
+    public long countMappings(String realmId, CredentialStatusFilter filter) {
         AtomicReference<Long> result = new AtomicReference<>(0L);
 
         withEntityManagerInTransaction(em -> {
-            String q = """
-                        SELECT COUNT(m) FROM StatusListMappingEntity m
-                        WHERE m.realmId = :realmId
-                    """;
+            StringBuilder jpql = new StringBuilder(
+                    "SELECT COUNT(m) FROM StatusListMappingEntity m WHERE m.realmId = :realmId");
+            appendFilterClauses(jpql, filter);
 
-            TypedQuery<Long> query = em.createQuery(q, Long.class);
+            TypedQuery<Long> query = em.createQuery(jpql.toString(), Long.class);
             query.setParameter("realmId", realmId);
+            setFilterParameters(query, filter);
 
             result.set(query.getSingleResult());
         });
 
         return result.get();
+    }
+
+    private static void appendFilterClauses(StringBuilder jpql, CredentialStatusFilter filter) {
+        if (filter == null) {
+            return;
+        }
+        if (filter.userId() != null) {
+            jpql.append(" AND m.userId = :userId");
+        }
+        if (filter.tokenStatus() != null) {
+            jpql.append(" AND m.tokenStatus = :tokenStatus");
+        }
+        if (filter.claims() != null) {
+            for (int i = 0; i < filter.claims().size(); i++) {
+                jpql.append(" AND m.metadata LIKE :claim").append(i);
+            }
+        }
+    }
+
+    private static <T> void setFilterParameters(TypedQuery<T> query, CredentialStatusFilter filter) {
+        if (filter == null) {
+            return;
+        }
+        if (filter.userId() != null) {
+            query.setParameter("userId", filter.userId());
+        }
+        if (filter.tokenStatus() != null) {
+            query.setParameter("tokenStatus", filter.tokenStatus());
+        }
+        if (filter.claims() != null) {
+            for (int i = 0; i < filter.claims().size(); i++) {
+                query.setParameter("claim" + i, "%" + filter.claims().get(i) + "%");
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusFilter.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusFilter.java
@@ -1,0 +1,26 @@
+package com.adorsys.keycloakstatuslist.model;
+
+import java.util.List;
+
+/**
+ * Filter criteria for querying credential status entries.
+ *
+ * @param userId       user ID to filter by (resolved from username at the resource layer)
+ * @param tokenStatus  token status to filter by (VALID or INVALID)
+ * @param claims       substring patterns to match against the metadata JSON column (ANDed)
+ */
+public record CredentialStatusFilter(
+        String userId,
+        TokenStatus tokenStatus,
+        List<String> claims) {
+
+    /** A filter that matches everything. */
+    public static final CredentialStatusFilter EMPTY = new CredentialStatusFilter(null, null, List.of());
+
+    /**
+     * Returns true if no filter criteria are set.
+     */
+    public boolean isEmpty() {
+        return userId == null && tokenStatus == null && (claims == null || claims.isEmpty());
+    }
+}

--- a/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusPage.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusPage.java
@@ -1,0 +1,13 @@
+package com.adorsys.keycloakstatuslist.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * Paginated response containing credential status entries.
+ */
+public record CredentialStatusPage(
+        @JsonProperty("items") List<CredentialStatusResponse> items,
+        @JsonProperty("total") long total,
+        @JsonProperty("offset") int offset,
+        @JsonProperty("limit") int limit) {}

--- a/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusResponse.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusResponse.java
@@ -1,0 +1,18 @@
+package com.adorsys.keycloakstatuslist.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
+
+/**
+ * Response model representing a single credential's status list mapping entry,
+ * returned by the admin credentials endpoint.
+ */
+public record CredentialStatusResponse(
+        @JsonProperty("token_id") String tokenId,
+        @JsonProperty("user_id") String userId,
+        @JsonProperty("username") String username,
+        @JsonProperty("status") String status,
+        @JsonProperty("status_list_id") String statusListId,
+        @JsonProperty("index") long index,
+        @JsonProperty("created_timestamp") long createdTimestamp,
+        @JsonRawValue @JsonProperty("metadata") String metadata) {}

--- a/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusResponse.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusResponse.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonRawValue;
  * returned by the admin credentials endpoint.
  */
 public record CredentialStatusResponse(
+        @JsonProperty("id") String id,
         @JsonProperty("token_id") String tokenId,
         @JsonProperty("user_id") String userId,
         @JsonProperty("username") String username,

--- a/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusUpdateRequest.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/model/CredentialStatusUpdateRequest.java
@@ -1,0 +1,8 @@
+package com.adorsys.keycloakstatuslist.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request model for updating the status of a credential via the admin endpoint.
+ */
+public record CredentialStatusUpdateRequest(@JsonProperty("status") String status) {}

--- a/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
@@ -150,6 +150,9 @@ public class StatusListAdminResource {
                     .build();
         }
 
+        mapping.setTokenStatus(newStatus);
+        repository.updateMapping(mapping);
+
         logger.infof("Request ID: %s, Updated credential %s to status %s", requestId, id, newStatus.getValue());
         return Response.ok(toResponse(mapping, realm)).build();
     }
@@ -161,7 +164,7 @@ public class StatusListAdminResource {
                 mapping.getTokenId(),
                 mapping.getUserId(),
                 username,
-                mapping.getStatus() != null ? mapping.getStatus().name() : null,
+                mapping.getTokenStatus() != null ? mapping.getTokenStatus().name() : null,
                 mapping.getStatusListId(),
                 mapping.getIdx(),
                 mapping.getCreatedTimestamp(),

--- a/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
@@ -1,0 +1,126 @@
+package com.adorsys.keycloakstatuslist.resource;
+
+import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
+import com.adorsys.keycloakstatuslist.jpa.repository.StatusListRepository;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusPage;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusResponse;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.jboss.logging.Logger;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.services.managers.AppAuthManager;
+import org.keycloak.services.managers.AuthenticationManager;
+import org.keycloak.services.resources.admin.AdminAuth;
+
+/**
+ * Admin REST resource for querying credential status list mappings.
+ * Requires realm admin authentication (realm-admin role on the realm-management client).
+ */
+public class StatusListAdminResource {
+
+    private static final Logger logger = Logger.getLogger(StatusListAdminResource.class);
+    static final int MAX_LIMIT = 100;
+
+    private final KeycloakSession session;
+    private final StatusListRepository repository;
+
+    public StatusListAdminResource(KeycloakSession session) {
+        this(session, new StatusListRepository(session));
+    }
+
+    StatusListAdminResource(KeycloakSession session, StatusListRepository repository) {
+        this.session = session;
+        this.repository = repository;
+    }
+
+    /**
+     * Returns a paginated list of credential status entries for the current realm.
+     *
+     * @param offset zero-based pagination offset
+     * @param limit maximum number of entries to return (capped at 100)
+     * @return paginated response with credential status entries
+     */
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response getCredentials(
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("20") int limit) {
+
+        AdminAuth auth = authenticateAdmin();
+        if (auth == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        RealmModel realm = session.getContext().getRealm();
+        if (!hasRealmAdminRole(auth, realm)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+
+        int effectiveOffset = Math.max(0, offset);
+        int effectiveLimit = Math.min(Math.max(1, limit), MAX_LIMIT);
+        String realmId = realm.getId();
+
+        long total = repository.countMappings(realmId);
+        List<StatusListMappingEntity> mappings = repository.getMappings(realmId, effectiveOffset, effectiveLimit);
+
+        List<CredentialStatusResponse> items = mappings.stream()
+                .map(m -> toResponse(m, realm))
+                .toList();
+
+        CredentialStatusPage page = new CredentialStatusPage(items, total, effectiveOffset, effectiveLimit);
+        return Response.ok(page).build();
+    }
+
+    private CredentialStatusResponse toResponse(StatusListMappingEntity mapping, RealmModel realm) {
+        String username = resolveUsername(mapping.getUserId(), realm);
+        return new CredentialStatusResponse(
+                mapping.getTokenId(),
+                mapping.getUserId(),
+                username,
+                mapping.getStatus() != null ? mapping.getStatus().name() : null,
+                mapping.getStatusListId(),
+                mapping.getIdx(),
+                mapping.getCreatedTimestamp(),
+                mapping.getMetadata());
+    }
+
+    private String resolveUsername(String userId, RealmModel realm) {
+        if (userId == null) {
+            return null;
+        }
+        UserModel user = session.users().getUserById(realm, userId);
+        return user != null ? user.getUsername() : null;
+    }
+
+    AdminAuth authenticateAdmin() {
+        AuthenticationManager.AuthResult authResult =
+                new AppAuthManager.BearerTokenAuthenticator(session).authenticate();
+        if (authResult == null) {
+            return null;
+        }
+        return new AdminAuth(
+                session.getContext().getRealm(),
+                authResult.getToken(),
+                authResult.getUser(),
+                authResult.getClient());
+    }
+
+    static boolean hasRealmAdminRole(AdminAuth auth, RealmModel realm) {
+        String realmManagementClientId = realm.getClientByClientId("realm-management") != null
+                ? "realm-management"
+                : "master-realm";
+        org.keycloak.models.ClientModel realmManagementClient = realm.getClientByClientId(realmManagementClientId);
+        if (realmManagementClient == null) {
+            logger.warnf("Could not find realm management client for realm: %s", realm.getName());
+            return false;
+        }
+        return auth.hasAppRole(realmManagementClient, "realm-admin");
+    }
+}

--- a/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
@@ -1,16 +1,25 @@
 package com.adorsys.keycloakstatuslist.resource;
 
+import com.adorsys.keycloakstatuslist.exception.StatusListException;
 import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
 import com.adorsys.keycloakstatuslist.jpa.repository.StatusListRepository;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusPage;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusResponse;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusUpdateRequest;
+import com.adorsys.keycloakstatuslist.model.TokenStatus;
+import com.adorsys.keycloakstatuslist.service.StatusListService;
+import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.PUT;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
+import java.util.UUID;
 import org.jboss.logging.Logger;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
@@ -20,7 +29,7 @@ import org.keycloak.services.managers.AuthenticationManager;
 import org.keycloak.services.resources.admin.AdminAuth;
 
 /**
- * Admin REST resource for querying credential status list mappings.
+ * Admin REST resource for querying and updating credential status list mappings.
  * Requires realm admin authentication (realm-admin role on the realm-management client).
  */
 public class StatusListAdminResource {
@@ -30,14 +39,17 @@ public class StatusListAdminResource {
 
     private final KeycloakSession session;
     private final StatusListRepository repository;
+    private final StatusListService statusListService;
 
-    public StatusListAdminResource(KeycloakSession session) {
-        this(session, new StatusListRepository(session));
+    public StatusListAdminResource(KeycloakSession session, StatusListService statusListService) {
+        this(session, new StatusListRepository(session), statusListService);
     }
 
-    StatusListAdminResource(KeycloakSession session, StatusListRepository repository) {
+    StatusListAdminResource(
+            KeycloakSession session, StatusListRepository repository, StatusListService statusListService) {
         this.session = session;
         this.repository = repository;
+        this.statusListService = statusListService;
     }
 
     /**
@@ -78,9 +90,74 @@ public class StatusListAdminResource {
         return Response.ok(page).build();
     }
 
+    /**
+     * Updates the token status of a credential on the status list server.
+     *
+     * @param id the primary key of the status list mapping entry
+     * @param request the update request containing the new status (VALID or INVALID)
+     * @return the updated credential status entry
+     */
+    @PUT
+    @Path("/{id}")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public Response updateCredentialStatus(@PathParam("id") String id, CredentialStatusUpdateRequest request) {
+        AdminAuth auth = authenticateAdmin();
+        if (auth == null) {
+            return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+
+        RealmModel realm = session.getContext().getRealm();
+        if (!hasRealmAdminRole(auth, realm)) {
+            return Response.status(Response.Status.FORBIDDEN).build();
+        }
+
+        if (request == null || request.status() == null || request.status().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"error\":\"status is required\"}")
+                    .build();
+        }
+
+        TokenStatus newStatus;
+        try {
+            newStatus = TokenStatus.valueOf(request.status());
+        } catch (IllegalArgumentException e) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"error\":\"status must be VALID or INVALID\"}")
+                    .build();
+        }
+
+        StatusListMappingEntity mapping = repository.findById(id);
+        if (mapping == null || !realm.getId().equals(mapping.getRealmId())) {
+            return Response.status(Response.Status.NOT_FOUND)
+                    .entity("{\"error\":\"credential not found\"}")
+                    .build();
+        }
+
+        String requestId = UUID.randomUUID().toString();
+        StatusListService.StatusListPayload payload = new StatusListService.StatusListPayload(
+                mapping.getStatusListId(),
+                List.of(new StatusListService.StatusListPayload.StatusEntry(mapping.getIdx(), newStatus.getValue())));
+
+        try {
+            statusListService.updateStatusList(payload, requestId);
+        } catch (StatusListException e) {
+            logger.errorf(
+                    "Request ID: %s, Failed to update credential status for mapping %s: %s",
+                    requestId, id, e.getMessage());
+            return Response.status(Response.Status.BAD_GATEWAY)
+                    .entity("{\"error\":\"failed to update status on status list server\"}")
+                    .build();
+        }
+
+        logger.infof("Request ID: %s, Updated credential %s to status %s", requestId, id, newStatus.getValue());
+        return Response.ok(toResponse(mapping, realm)).build();
+    }
+
     private CredentialStatusResponse toResponse(StatusListMappingEntity mapping, RealmModel realm) {
         String username = resolveUsername(mapping.getUserId(), realm);
         return new CredentialStatusResponse(
+                mapping.getId(),
                 mapping.getTokenId(),
                 mapping.getUserId(),
                 username,

--- a/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResource.java
@@ -3,6 +3,7 @@ package com.adorsys.keycloakstatuslist.resource;
 import com.adorsys.keycloakstatuslist.exception.StatusListException;
 import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
 import com.adorsys.keycloakstatuslist.jpa.repository.StatusListRepository;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusFilter;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusPage;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusResponse;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusUpdateRequest;
@@ -36,6 +37,7 @@ public class StatusListAdminResource {
 
     private static final Logger logger = Logger.getLogger(StatusListAdminResource.class);
     static final int MAX_LIMIT = 100;
+    static final String NON_MATCHING_USER_ID = "__non_matching__";
 
     private final KeycloakSession session;
     private final StatusListRepository repository;
@@ -53,17 +55,24 @@ public class StatusListAdminResource {
     }
 
     /**
-     * Returns a paginated list of credential status entries for the current realm.
+     * Returns a paginated list of credential status entries for the current realm,
+     * optionally filtered by username, token status, and metadata claims.
      *
-     * @param offset zero-based pagination offset
-     * @param limit maximum number of entries to return (capped at 100)
+     * @param offset   zero-based pagination offset
+     * @param limit    maximum number of entries to return (capped at 100)
+     * @param username filter by exact username (resolved to user ID)
+     * @param status   filter by token status (VALID or INVALID)
+     * @param claims   filter by metadata content (substring match, multiple values are ANDed)
      * @return paginated response with credential status entries
      */
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     public Response getCredentials(
             @QueryParam("offset") @DefaultValue("0") int offset,
-            @QueryParam("limit") @DefaultValue("20") int limit) {
+            @QueryParam("limit") @DefaultValue("20") int limit,
+            @QueryParam("username") String username,
+            @QueryParam("status") String status,
+            @QueryParam("claims") List<String> claims) {
 
         AdminAuth auth = authenticateAdmin();
         if (auth == null) {
@@ -75,12 +84,20 @@ public class StatusListAdminResource {
             return Response.status(Response.Status.FORBIDDEN).build();
         }
 
+        CredentialStatusFilter filter = buildFilter(realm, username, status, claims);
+        if (filter == null) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("{\"error\":\"status must be VALID or INVALID\"}")
+                    .build();
+        }
+
         int effectiveOffset = Math.max(0, offset);
         int effectiveLimit = Math.min(Math.max(1, limit), MAX_LIMIT);
         String realmId = realm.getId();
 
-        long total = repository.countMappings(realmId);
-        List<StatusListMappingEntity> mappings = repository.getMappings(realmId, effectiveOffset, effectiveLimit);
+        long total = repository.countMappings(realmId, filter);
+        List<StatusListMappingEntity> mappings =
+                repository.getMappings(realmId, filter, effectiveOffset, effectiveLimit);
 
         List<CredentialStatusResponse> items = mappings.stream()
                 .map(m -> toResponse(m, realm))
@@ -88,6 +105,36 @@ public class StatusListAdminResource {
 
         CredentialStatusPage page = new CredentialStatusPage(items, total, effectiveOffset, effectiveLimit);
         return Response.ok(page).build();
+    }
+
+    /**
+     * Builds a filter from the query parameters. Returns null if the status value is invalid.
+     */
+    CredentialStatusFilter buildFilter(RealmModel realm, String username, String status, List<String> claims) {
+        String userId = null;
+        if (username != null && !username.isBlank()) {
+            UserModel user = session.users().getUserByUsername(realm, username.trim());
+            if (user == null) {
+                userId = NON_MATCHING_USER_ID;
+            } else {
+                userId = user.getId();
+            }
+        }
+
+        TokenStatus tokenStatus = null;
+        if (status != null && !status.isBlank()) {
+            try {
+                tokenStatus = TokenStatus.valueOf(status.trim());
+            } catch (IllegalArgumentException e) {
+                return null;
+            }
+        }
+
+        List<String> effectiveClaims = claims != null
+                ? claims.stream().filter(c -> c != null && !c.isBlank()).toList()
+                : List.of();
+
+        return new CredentialStatusFilter(userId, tokenStatus, effectiveClaims);
     }
 
     /**

--- a/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceProvider.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceProvider.java
@@ -1,11 +1,18 @@
 package com.adorsys.keycloakstatuslist.resource;
 
+import com.adorsys.keycloakstatuslist.client.ApacheHttpStatusListClient;
+import com.adorsys.keycloakstatuslist.client.StatusListHttpClient;
+import com.adorsys.keycloakstatuslist.config.StatusListConfig;
+import com.adorsys.keycloakstatuslist.service.CircuitBreaker;
+import com.adorsys.keycloakstatuslist.service.CryptoIdentityService;
+import com.adorsys.keycloakstatuslist.service.CustomHttpClient;
+import com.adorsys.keycloakstatuslist.service.StatusListService;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.services.resource.RealmResourceProvider;
 
 /**
  * Realm resource provider that exposes the status list admin endpoint
- * under the realm's REST API at /realms/{realm}/status-list-admin/credentials.
+ * under the realm's REST API at /realms/{realm}/status-list-admin.
  */
 public class StatusListAdminResourceProvider implements RealmResourceProvider {
 
@@ -17,7 +24,29 @@ public class StatusListAdminResourceProvider implements RealmResourceProvider {
 
     @Override
     public Object getResource() {
-        return new StatusListAdminResource(session);
+        StatusListService statusListService = createStatusListService(session);
+        return new StatusListAdminResource(session, statusListService);
+    }
+
+    /**
+     * Builds a StatusListService for the given session (config, circuit breaker, HTTP client).
+     */
+    private static StatusListService createStatusListService(KeycloakSession session) {
+        StatusListConfig config = new StatusListConfig(session.getContext().getRealm());
+        CryptoIdentityService cryptoIdentityService = new CryptoIdentityService(session);
+
+        CircuitBreaker circuitBreaker = null;
+        if (config.getIssuanceTimeout() > 0) {
+            circuitBreaker = CircuitBreaker.getInstance(config);
+        }
+
+        StatusListHttpClient httpClient = new ApacheHttpStatusListClient(
+                config.getServerUrl(),
+                cryptoIdentityService.getJwtToken(config),
+                CustomHttpClient.getHttpClient(config),
+                circuitBreaker);
+
+        return new StatusListService(httpClient);
     }
 
     @Override

--- a/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceProvider.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceProvider.java
@@ -1,0 +1,27 @@
+package com.adorsys.keycloakstatuslist.resource;
+
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.services.resource.RealmResourceProvider;
+
+/**
+ * Realm resource provider that exposes the status list admin endpoint
+ * under the realm's REST API at /realms/{realm}/status-list-admin/credentials.
+ */
+public class StatusListAdminResourceProvider implements RealmResourceProvider {
+
+    private final KeycloakSession session;
+
+    public StatusListAdminResourceProvider(KeycloakSession session) {
+        this.session = session;
+    }
+
+    @Override
+    public Object getResource() {
+        return new StatusListAdminResource(session);
+    }
+
+    @Override
+    public void close() {
+        // No resources to close
+    }
+}

--- a/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceProviderFactory.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceProviderFactory.java
@@ -1,0 +1,42 @@
+package com.adorsys.keycloakstatuslist.resource;
+
+import org.keycloak.Config;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.KeycloakSessionFactory;
+import org.keycloak.services.resource.RealmResourceProvider;
+import org.keycloak.services.resource.RealmResourceProviderFactory;
+
+/**
+ * Factory for the status list admin resource provider.
+ * Registers the provider under the ID "status-list-admin", making the endpoint
+ * available at /realms/{realm}/status-list-admin.
+ */
+public class StatusListAdminResourceProviderFactory implements RealmResourceProviderFactory {
+
+    public static final String PROVIDER_ID = "status-list-admin";
+
+    @Override
+    public RealmResourceProvider create(KeycloakSession session) {
+        return new StatusListAdminResourceProvider(session);
+    }
+
+    @Override
+    public void init(Config.Scope config) {
+        // No initialization required
+    }
+
+    @Override
+    public void postInit(KeycloakSessionFactory factory) {
+        // No post-initialization required
+    }
+
+    @Override
+    public void close() {
+        // No resources to close
+    }
+
+    @Override
+    public String getId() {
+        return PROVIDER_ID;
+    }
+}

--- a/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
@@ -1,6 +1,7 @@
 package com.adorsys.keycloakstatuslist.service;
 
 import com.adorsys.keycloakstatuslist.config.StatusListConfig;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -8,18 +9,25 @@ import java.net.URISyntaxException;
 import java.security.KeyStore;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
 import java.util.function.Function;
 import javax.net.ssl.SSLContext;
+
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.routing.DefaultProxyRoutePlanner;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
 import org.apache.hc.client5.http.ssl.TrustAllStrategy;
+import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
@@ -33,7 +41,11 @@ public class CustomHttpClient {
 
     private static final Logger logger = Logger.getLogger(CustomHttpClient.class);
 
+    private static final String[] PROXY_VARS = {"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"};
+    private static final String[] NO_PROXY_VARS = {"NO_PROXY", "no_proxy"};
+
     public static final int DEFAULT_CONNECT_TIMEOUT = 30000;
+
 
     /**
      * Creates an HTTP client for issuance operations (runtime/foreground).
@@ -43,6 +55,7 @@ public class CustomHttpClient {
      * @return configured HTTP client
      */
     public static CloseableHttpClient getIssuanceHttpClient(StatusListConfig config) {
+        // Issuance path: minimal/no retries to avoid blocking the user thread for too long
         return createHttpClient(config.getIssuanceTimeout(), 0, config);
     }
 
@@ -76,10 +89,17 @@ public class CustomHttpClient {
                 .setDefaultRequestConfig(requestConfig)
                 .setRetryStrategy(getHttpRequestRetryStrategy(maxRetries));
 
+        // support usage of a http proxy - reuses the standard keycloak proxy/no-proxy env-vars
         HttpHost proxy = resolveProxy();
         if (proxy != null) {
-            builder.setProxy(proxy);
             logger.infof("Using HTTP proxy: %s", proxy);
+            List<String> noProxyPatterns = resolveNoProxy();
+            if (noProxyPatterns.isEmpty()) {
+                builder.setProxy(proxy);
+            } else {
+                builder.setRoutePlanner(new NoProxyAwareRoutePlanner(proxy, noProxyPatterns));
+                logger.infof("NO_PROXY patterns: %s", noProxyPatterns);
+            }
         }
 
         HttpClientConnectionManager connectionManager = buildConnectionManager(config);
@@ -181,9 +201,8 @@ public class CustomHttpClient {
      * @return the proxy HttpHost, or null if no proxy is configured
      */
     static HttpHost resolveProxy(Function<String, String> envLookup) {
-        String[] candidates = {"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"};
         String proxyUrl = null;
-        for (String name : candidates) {
+        for (String name : PROXY_VARS) {
             proxyUrl = envLookup.apply(name);
             if (proxyUrl != null && !proxyUrl.isEmpty()) {
                 break;
@@ -206,6 +225,81 @@ public class CustomHttpClient {
             logger.warnf("Invalid proxy URL '%s': %s", proxyUrl, e.getMessage());
             return null;
         }
+    }
+
+    /**
+     * Resolves the NO_PROXY exclusion list from environment variables.
+     *
+     * @return list of lowercase hostname patterns to bypass the proxy for
+     */
+    static List<String> resolveNoProxy() {
+        return resolveNoProxy(System::getenv);
+    }
+
+    /**
+     * Resolves the NO_PROXY exclusion list using the provided environment variable lookup function.
+     * Checks NO_PROXY and no_proxy in order.
+     *
+     * @param envLookup function to look up environment variable values by name
+     * @return list of lowercase hostname patterns to bypass the proxy for
+     */
+    static List<String> resolveNoProxy(Function<String, String> envLookup) {
+        String noProxy = null;
+        for (String name : NO_PROXY_VARS) {
+            noProxy = envLookup.apply(name);
+            if (noProxy != null && !noProxy.isEmpty()) {
+                break;
+            }
+        }
+        if (noProxy == null || noProxy.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<String> patterns = new ArrayList<>();
+        for (String entry : noProxy.split(",")) {
+            String trimmed = entry.trim();
+            if (!trimmed.isEmpty()) {
+                patterns.add(trimmed.toLowerCase(Locale.ROOT));
+            }
+        }
+        return patterns;
+    }
+
+    /**
+     * Checks whether the given hostname should bypass the proxy based on NO_PROXY patterns.
+     * <p>
+     * Matching rules:
+     * <ul>
+     *   <li>{@code *} matches all hosts</li>
+     *   <li>{@code .example.com} matches {@code example.com} and {@code sub.example.com}</li>
+     *   <li>{@code example.com} matches {@code example.com} and {@code sub.example.com}</li>
+     * </ul>
+     * Matching is case-insensitive.
+     *
+     * @param hostname        the target hostname
+     * @param noProxyPatterns lowercase patterns from NO_PROXY
+     * @return true if the proxy should be bypassed for this host
+     */
+    static boolean isNoProxyHost(String hostname, List<String> noProxyPatterns) {
+        if (noProxyPatterns.isEmpty()) {
+            return false;
+        }
+        String host = hostname.toLowerCase(Locale.ROOT);
+        for (String pattern : noProxyPatterns) {
+            if ("*".equals(pattern)) {
+                return true;
+            }
+            if (pattern.startsWith(".")) {
+                String domain = pattern.substring(1);
+                if (host.equals(domain) || host.endsWith(pattern)) {
+                    return true;
+                }
+            } else {
+                if (host.equals(pattern) || host.endsWith("." + pattern)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static HttpRequestRetryStrategy getHttpRequestRetryStrategy(int maxRetries) {
@@ -235,5 +329,27 @@ public class CustomHttpClient {
                 return TimeValue.ofSeconds((long) Math.pow(2, execCount - 1));
             }
         };
+    }
+
+    /**
+     * Route planner that bypasses the proxy for hosts matching the NO_PROXY patterns.
+     */
+    private static class NoProxyAwareRoutePlanner extends DefaultProxyRoutePlanner {
+
+        private final List<String> noProxyPatterns;
+
+        NoProxyAwareRoutePlanner(HttpHost proxy, List<String> noProxyPatterns) {
+            super(proxy);
+            this.noProxyPatterns = noProxyPatterns;
+        }
+
+        @Override
+        protected HttpHost determineProxy(HttpHost target, HttpContext context) throws HttpException {
+            if (isNoProxyHost(target.getHostName(), noProxyPatterns)) {
+                logger.debugf("Bypassing proxy for host: %s (matched NO_PROXY)", target.getHostName());
+                return null;
+            }
+            return super.determineProxy(target, context);
+        }
     }
 }

--- a/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
@@ -1,19 +1,30 @@
 package com.adorsys.keycloakstatuslist.service;
 
 import com.adorsys.keycloakstatuslist.config.StatusListConfig;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
 import java.util.function.Function;
+import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
+import org.apache.hc.client5.http.ssl.TrustAllStrategy;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.protocol.HttpContext;
+import org.apache.hc.core5.ssl.SSLContextBuilder;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
 import org.jboss.logging.Logger;
@@ -32,8 +43,7 @@ public class CustomHttpClient {
      * @return configured HTTP client
      */
     public static CloseableHttpClient getIssuanceHttpClient(StatusListConfig config) {
-        // Issuance path: minimal/no retries to avoid blocking the user thread for too long
-        return createHttpClient(config.getIssuanceTimeout(), 0);
+        return createHttpClient(config.getIssuanceTimeout(), 0, config);
     }
 
     /**
@@ -44,7 +54,7 @@ public class CustomHttpClient {
      * @return configured HTTP client
      */
     public static CloseableHttpClient getRegistrationHttpClient(StatusListConfig config) {
-        return createHttpClient(config.getRegistrationTimeout(), config.getRegistrationRetries());
+        return createHttpClient(config.getRegistrationTimeout(), config.getRegistrationRetries(), config);
     }
 
     /**
@@ -54,7 +64,7 @@ public class CustomHttpClient {
         return getIssuanceHttpClient(config);
     }
 
-    private static CloseableHttpClient createHttpClient(int timeoutMs, int maxRetries) {
+    private static CloseableHttpClient createHttpClient(int timeoutMs, int maxRetries, StatusListConfig config) {
         if (timeoutMs <= 0) {
             timeoutMs = DEFAULT_CONNECT_TIMEOUT;
         }
@@ -72,7 +82,85 @@ public class CustomHttpClient {
             logger.infof("Using HTTP proxy: %s", proxy);
         }
 
+        HttpClientConnectionManager connectionManager = buildConnectionManager(config);
+        if (connectionManager != null) {
+            builder.setConnectionManager(connectionManager);
+        }
+
         return builder.build();
+    }
+
+    /**
+     * Builds a connection manager with custom TLS configuration if needed.
+     *
+     * @param config the status list configuration containing TLS settings
+     * @return a configured connection manager, or null to use the default
+     */
+    static HttpClientConnectionManager buildConnectionManager(StatusListConfig config) {
+        SSLContext sslContext = buildSslContext(config);
+        if (sslContext == null) {
+            return null;
+        }
+
+        SSLConnectionSocketFactoryBuilder sslSocketBuilder =
+                SSLConnectionSocketFactoryBuilder.create().setSslContext(sslContext);
+
+        if (config.isTlsTrustAll()) {
+            sslSocketBuilder.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+        }
+
+        return PoolingHttpClientConnectionManagerBuilder.create()
+                .setSSLSocketFactory(sslSocketBuilder.build())
+                .build();
+    }
+
+    /**
+     * Builds an SSLContext based on the TLS configuration.
+     * Returns null when the default JVM trust store should be used.
+     *
+     * @param config the status list configuration
+     * @return a custom SSLContext, or null for JVM defaults
+     */
+    static SSLContext buildSslContext(StatusListConfig config) {
+        try {
+            if (config.isTlsTrustAll()) {
+                logger.warn("TLS trust-all is enabled — all server certificates will be accepted");
+                return SSLContextBuilder.create()
+                        .loadTrustMaterial(TrustAllStrategy.INSTANCE)
+                        .build();
+            }
+
+            String caCertPath = config.getTlsCaCertPath();
+            if (caCertPath != null && !caCertPath.isEmpty()) {
+                logger.infof("Loading custom CA certificate from: %s", caCertPath);
+                return buildSslContextFromCaCert(caCertPath);
+            }
+        } catch (Exception e) {
+            logger.errorf(e, "Failed to build custom SSLContext, falling back to JVM defaults");
+        }
+        return null;
+    }
+
+    /**
+     * Builds an SSLContext that trusts a specific PEM-encoded CA certificate file.
+     *
+     * @param caCertPath path to the PEM-encoded CA certificate
+     * @return configured SSLContext
+     * @throws Exception if the certificate cannot be loaded or the SSLContext cannot be built
+     */
+    static SSLContext buildSslContextFromCaCert(String caCertPath) throws Exception {
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+        X509Certificate caCert;
+        try (FileInputStream fis = new FileInputStream(caCertPath)) {
+            caCert = (X509Certificate) cf.generateCertificate(fis);
+        }
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+        trustStore.setCertificateEntry("status-list-ca", caCert);
+
+        return SSLContextBuilder.create()
+                .loadTrustMaterial(trustStore, null)
+                .build();
     }
 
     /**

--- a/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
@@ -190,14 +190,17 @@ public class CustomHttpClient {
             }
         }
         if (proxyUrl == null || proxyUrl.isEmpty()) {
+            logger.info("Empty proxy url.");
             return null;
         }
         try {
+            logger.info("Setup proxy");
             URI uri = new URI(proxyUrl);
             int port = uri.getPort();
             if (port < 0) {
                 port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
             }
+            logger.infof("Use proxy %s.", uri.getHost());
             return new HttpHost(uri.getScheme(), uri.getHost(), port);
         } catch (URISyntaxException e) {
             logger.warnf("Invalid proxy URL '%s': %s", proxyUrl, e.getMessage());

--- a/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
+++ b/src/main/java/com/adorsys/keycloakstatuslist/service/CustomHttpClient.java
@@ -2,10 +2,15 @@ package com.adorsys.keycloakstatuslist.service;
 
 import com.adorsys.keycloakstatuslist.config.StatusListConfig;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.function.Function;
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -57,10 +62,59 @@ public class CustomHttpClient {
                 .setConnectionRequestTimeout(Timeout.ofMilliseconds(timeoutMs))
                 .setResponseTimeout(Timeout.ofMilliseconds(timeoutMs))
                 .build();
-        return HttpClients.custom()
+        HttpClientBuilder builder = HttpClients.custom()
                 .setDefaultRequestConfig(requestConfig)
-                .setRetryStrategy(getHttpRequestRetryStrategy(maxRetries))
-                .build();
+                .setRetryStrategy(getHttpRequestRetryStrategy(maxRetries));
+
+        HttpHost proxy = resolveProxy();
+        if (proxy != null) {
+            builder.setProxy(proxy);
+            logger.infof("Using HTTP proxy: %s", proxy);
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Resolves an HTTP proxy from the HTTPS_PROXY or HTTP_PROXY environment variables.
+     * Apache HttpClient 5 does not read these variables automatically.
+     *
+     * @return the proxy HttpHost, or null if no proxy is configured
+     */
+    static HttpHost resolveProxy() {
+        return resolveProxy(System::getenv);
+    }
+
+    /**
+     * Resolves an HTTP proxy using the provided environment variable lookup function.
+     * Checks HTTPS_PROXY, https_proxy, HTTP_PROXY, http_proxy in order.
+     *
+     * @param envLookup function to look up environment variable values by name
+     * @return the proxy HttpHost, or null if no proxy is configured
+     */
+    static HttpHost resolveProxy(Function<String, String> envLookup) {
+        String[] candidates = {"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"};
+        String proxyUrl = null;
+        for (String name : candidates) {
+            proxyUrl = envLookup.apply(name);
+            if (proxyUrl != null && !proxyUrl.isEmpty()) {
+                break;
+            }
+        }
+        if (proxyUrl == null || proxyUrl.isEmpty()) {
+            return null;
+        }
+        try {
+            URI uri = new URI(proxyUrl);
+            int port = uri.getPort();
+            if (port < 0) {
+                port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+            }
+            return new HttpHost(uri.getScheme(), uri.getHost(), port);
+        } catch (URISyntaxException e) {
+            logger.warnf("Invalid proxy URL '%s': %s", proxyUrl, e.getMessage());
+            return null;
+        }
     }
 
     private static HttpRequestRetryStrategy getHttpRequestRetryStrategy(int maxRetries) {

--- a/src/main/resources/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
+++ b/src/main/resources/META-INF/services/org.keycloak.services.resource.RealmResourceProviderFactory
@@ -1,1 +1,2 @@
 com.adorsys.keycloakstatuslist.service.nonce.NonceCacheServiceProviderFactory
+com.adorsys.keycloakstatuslist.resource.StatusListAdminResourceProviderFactory

--- a/src/main/resources/META-INF/statuslist-changelog.xml
+++ b/src/main/resources/META-INF/statuslist-changelog.xml
@@ -58,4 +58,10 @@
         </createIndex>
     </changeSet>
 
+    <changeSet id="add-metadata-to-status-list-mapping" author="adorsys">
+        <addColumn tableName="status_list_mapping">
+            <column name="metadata" type="clob"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/META-INF/statuslist-changelog.xml
+++ b/src/main/resources/META-INF/statuslist-changelog.xml
@@ -64,4 +64,10 @@
         </addColumn>
     </changeSet>
 
+    <changeSet id="add-token-status-to-status-list-mapping" author="adorsys">
+        <addColumn tableName="status_list_mapping">
+            <column name="token_status" type="varchar(32)" defaultValue="VALID"/>
+        </addColumn>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
@@ -30,15 +30,21 @@ import com.adorsys.keycloakstatuslist.model.Status;
 import com.adorsys.keycloakstatuslist.model.StatusListClaim;
 import com.adorsys.keycloakstatuslist.model.TokenStatus;
 import com.adorsys.keycloakstatuslist.service.StatusListService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.PersistenceException;
 import jakarta.ws.rs.core.UriBuilder;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.protocol.ProtocolMapper;
 import org.mockito.ArgumentCaptor;
@@ -60,9 +66,13 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
     StatusListProtocolMapper mapper;
     HashMap<String, Object> claims;
     StatusListRepository statusListRepository;
+    HashMap<String, String> mapperConfig;
 
     @BeforeEach
     void setup() {
+        mapperConfig = new HashMap<>();
+        lenient().when(mapperModel.getConfig()).thenReturn(mapperConfig);
+
         mapper = spy(new StatusListProtocolMapper(session));
         setPrivateField(mapper, "mapperModel", mapperModel);
         setPrivateField(mapper, "statusListService", statusListService);
@@ -109,7 +119,7 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
         assertEquals("Status List Claim Mapper", mapper.getDisplayType());
         assertTrue(mapper.getHelpText().contains("status list claim"));
         assertFalse(mapper.includeInMetadata());
-        assertTrue(mapper.getIndividualConfigProperties().isEmpty());
+        assertFalse(mapper.getIndividualConfigProperties().isEmpty());
         mapper.close();
     }
 
@@ -312,6 +322,109 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
         mapper.setClaim(claims, userSession);
 
         assertThat(claims.keySet(), hasItem(Constants.STATUS_CLAIM_KEY));
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", " , "})
+    void shouldReturnNullMetadata_WhenNoClaimPathsConfigured(String configValue) {
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, configValue);
+
+        String metadata = mapper.extractMetadata(claims);
+
+        assertEquals(null, metadata);
+    }
+
+    @Test
+    void shouldExtractTopLevelClaimAsMetadata() throws JsonProcessingException {
+        claims.put("vct", "IdentityCredential");
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "vct");
+
+        String metadata = mapper.extractMetadata(claims);
+
+        Map<?, ?> parsed = new ObjectMapper().readValue(metadata, Map.class);
+        assertEquals("IdentityCredential", parsed.get("vct"));
+        assertEquals(1, parsed.size());
+    }
+
+    @Test
+    void shouldExtractNestedClaimAsMetadata() throws JsonProcessingException {
+        claims.put("sub", Map.of("email", "user@example.com", "name", "Jane"));
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "sub.email");
+
+        String metadata = mapper.extractMetadata(claims);
+
+        Map<?, ?> parsed = new ObjectMapper().readValue(metadata, Map.class);
+        assertEquals("user@example.com", parsed.get("sub.email"));
+        assertEquals(1, parsed.size());
+    }
+
+    @Test
+    void shouldExtractMultipleClaimPathsAsMetadata() throws JsonProcessingException {
+        claims.put("vct", "IdentityCredential");
+        claims.put("sub", Map.of("email", "user@example.com"));
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "vct, sub.email");
+
+        String metadata = mapper.extractMetadata(claims);
+
+        Map<?, ?> parsed = new ObjectMapper().readValue(metadata, Map.class);
+        assertEquals("IdentityCredential", parsed.get("vct"));
+        assertEquals("user@example.com", parsed.get("sub.email"));
+        assertEquals(2, parsed.size());
+    }
+
+    @Test
+    void shouldSkipMissingClaimPaths() throws JsonProcessingException {
+        claims.put("vct", "IdentityCredential");
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "vct, nonexistent");
+
+        String metadata = mapper.extractMetadata(claims);
+
+        Map<?, ?> parsed = new ObjectMapper().readValue(metadata, Map.class);
+        assertEquals("IdentityCredential", parsed.get("vct"));
+        assertEquals(1, parsed.size());
+    }
+
+    @Test
+    void shouldReturnNullMetadata_WhenAllClaimPathsMissing() {
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "nonexistent, also.missing");
+
+        String metadata = mapper.extractMetadata(claims);
+
+        assertEquals(null, metadata);
+    }
+
+    @Test
+    void shouldStoreMetadataInEntity_WhenClaimPathsConfigured() {
+        claims.put("vct", "IdentityCredential");
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "vct");
+        mockGetNextIndex();
+
+        mapper.setClaim(claims, userSession);
+
+        var entityCaptor = ArgumentCaptor.forClass(StatusListMappingEntity.class);
+        verify(entityManager).persist(entityCaptor.capture());
+        StatusListMappingEntity capturedEntity = entityCaptor.getValue();
+        assertThat(capturedEntity.getMetadata(), containsString("IdentityCredential"));
+    }
+
+    @Test
+    void shouldResolveClaimPath_WhenPathPointsToMapValue() {
+        Map<String, Object> nested = Map.of("level2", Map.of("level3", "deepValue"));
+        Map<String, Object> testClaims = Map.of("level1", nested);
+
+        Object result = StatusListProtocolMapper.resolveClaimPath(testClaims, "level1.level2.level3");
+
+        assertEquals("deepValue", result);
+    }
+
+    @Test
+    void shouldReturnNull_WhenPathTraversesNonMapValue() {
+        Map<String, Object> testClaims = Map.of("key", "stringValue");
+
+        Object result = StatusListProtocolMapper.resolveClaimPath(testClaims, "key.sub");
+
+        assertEquals(null, result);
     }
 
     private void mockDefaultRealmConfig() {

--- a/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
@@ -15,6 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.spy;
@@ -49,6 +50,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.protocol.ProtocolMapper;
+import org.keycloak.protocol.oid4vc.model.CredentialSubject;
+import org.keycloak.protocol.oid4vc.model.VerifiableCredential;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 
@@ -129,8 +132,9 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
     }
 
     @Test
-    void shouldNoOpForW3CVerifiableCredentialClaimSetter() {
-        mapper.setClaim((org.keycloak.protocol.oid4vc.model.VerifiableCredential) null, userSession);
+    void shouldNoOpForVerifiableCredentialClaimSetter_WhenNoPendingMapping() {
+        VerifiableCredential vc = new VerifiableCredential();
+        mapper.setClaim(vc, userSession);
     }
 
     @Test
@@ -407,9 +411,13 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
 
         mapper.setClaim(claims, userSession);
 
+        VerifiableCredential vc = buildVerifiableCredential(claims);
+        mapper.setClaim(vc, userSession);
+
         var entityCaptor = ArgumentCaptor.forClass(StatusListMappingEntity.class);
-        verify(entityManager).persist(entityCaptor.capture());
-        StatusListMappingEntity capturedEntity = entityCaptor.getValue();
+        verify(entityManager, atLeastOnce()).merge(entityCaptor.capture());
+        StatusListMappingEntity capturedEntity = entityCaptor.getAllValues()
+                .get(entityCaptor.getAllValues().size() - 1);
         assertThat(capturedEntity.getMetadata(), containsString("IdentityCredential"));
     }
 
@@ -464,6 +472,9 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
 
         mapper.setClaim(claims, userSession);
 
+        VerifiableCredential vc = buildVerifiableCredential(claims);
+        mapper.setClaim(vc, userSession);
+
         var entityCaptor = ArgumentCaptor.forClass(StatusListMappingEntity.class);
         verify(entityManager).persist(entityCaptor.capture());
         StatusListMappingEntity capturedEntity = entityCaptor.getValue();
@@ -477,9 +488,13 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
 
         mapper.setClaim(claims, userSession);
 
+        VerifiableCredential vc = buildVerifiableCredential(claims);
+        mapper.setClaim(vc, userSession);
+
         var entityCaptor = ArgumentCaptor.forClass(StatusListMappingEntity.class);
-        verify(entityManager).persist(entityCaptor.capture());
-        StatusListMappingEntity capturedEntity = entityCaptor.getValue();
+        verify(entityManager, atLeastOnce()).merge(entityCaptor.capture());
+        StatusListMappingEntity capturedEntity = entityCaptor.getAllValues()
+                .get(entityCaptor.getAllValues().size() - 1);
         Map<?, ?> parsed = new ObjectMapper().readValue(capturedEntity.getMetadata(), Map.class);
         assertEquals(List.of("VerifiableCredential", "UserCredential"), parsed.get("type"));
     }
@@ -561,6 +576,41 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
         lenient().when(clientScope.getProtocolMapperById(mapperId)).thenReturn(mapperModel);
         lenient().when(clientScope.getAttribute("vc.supported_credential_types")).thenReturn(String.join(",", types));
         lenient().when(realm.getClientScopesStream()).thenAnswer(inv -> Stream.of(clientScope));
+    }
+
+    /**
+     * Builds a VerifiableCredential with the given claims set on its credential subject,
+     * simulating the state after all mappers have populated the claims map.
+     */
+    private VerifiableCredential buildVerifiableCredential(Map<String, Object> claimsMap) {
+        VerifiableCredential vc = new VerifiableCredential();
+        CredentialSubject subject = new CredentialSubject();
+        subject.setClaims(new HashMap<>(claimsMap));
+        vc.setCredentialSubject(subject);
+        return vc;
+    }
+
+    @Test
+    void shouldExtractMetadataFromAllClaims_WhenSetClaimVCIsCalledAfterAllMappers()
+            throws JsonProcessingException {
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "firstName, lastName");
+        mockGetNextIndex();
+
+        mapper.setClaim(claims, userSession);
+
+        claims.put("firstName", "Jane");
+        claims.put("lastName", "Doe");
+
+        VerifiableCredential vc = buildVerifiableCredential(claims);
+        mapper.setClaim(vc, userSession);
+
+        var entityCaptor = ArgumentCaptor.forClass(StatusListMappingEntity.class);
+        verify(entityManager, atLeastOnce()).merge(entityCaptor.capture());
+        StatusListMappingEntity capturedEntity = entityCaptor.getAllValues()
+                .get(entityCaptor.getAllValues().size() - 1);
+        Map<?, ?> parsed = new ObjectMapper().readValue(capturedEntity.getMetadata(), Map.class);
+        assertEquals("Jane", parsed.get("firstName"));
+        assertEquals("Doe", parsed.get("lastName"));
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/StatusListProtocolMapperTest.java
@@ -39,12 +39,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Stream;
 import nl.altindag.log.LogCaptor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.keycloak.models.ClientScopeModel;
 import org.keycloak.models.ProtocolMapperModel;
 import org.keycloak.protocol.ProtocolMapper;
 import org.mockito.ArgumentCaptor;
@@ -62,6 +64,9 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
 
     @Mock
     StatusListService statusListService;
+
+    @Mock
+    ClientScopeModel clientScope;
 
     StatusListProtocolMapper mapper;
     HashMap<String, Object> claims;
@@ -427,6 +432,93 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
         assertEquals(null, result);
     }
 
+    @Test
+    void shouldIncludeCredentialTypesInMetadata_ByDefault() throws JsonProcessingException {
+        mockCredentialScope("VerifiableCredential", "UserCredential");
+
+        String metadata = mapper.extractMetadata(claims, List.of("VerifiableCredential", "UserCredential"));
+
+        Map<?, ?> parsed = new ObjectMapper().readValue(metadata, Map.class);
+        assertEquals(List.of("VerifiableCredential", "UserCredential"), parsed.get("type"));
+        assertEquals(1, parsed.size());
+    }
+
+    @Test
+    void shouldIncludeCredentialTypesAlongsideClaimPaths() throws JsonProcessingException {
+        claims.put("vct", "IdentityCredential");
+        mapperConfig.put(Constants.METADATA_CLAIM_PATHS_KEY, "vct");
+
+        String metadata = mapper.extractMetadata(claims, List.of("VerifiableCredential", "UserCredential"));
+
+        Map<?, ?> parsed = new ObjectMapper().readValue(metadata, Map.class);
+        assertEquals("IdentityCredential", parsed.get("vct"));
+        assertEquals(List.of("VerifiableCredential", "UserCredential"), parsed.get("type"));
+        assertEquals(2, parsed.size());
+    }
+
+    @Test
+    void shouldNotIncludeCredentialTypes_WhenFlagIsDisabled() {
+        mapperConfig.put(Constants.INCLUDE_CREDENTIAL_TYPES_KEY, "false");
+        mockCredentialScope("VerifiableCredential", "UserCredential");
+        mockGetNextIndex();
+
+        mapper.setClaim(claims, userSession);
+
+        var entityCaptor = ArgumentCaptor.forClass(StatusListMappingEntity.class);
+        verify(entityManager).persist(entityCaptor.capture());
+        StatusListMappingEntity capturedEntity = entityCaptor.getValue();
+        assertEquals(null, capturedEntity.getMetadata());
+    }
+
+    @Test
+    void shouldStoreCredentialTypesInEntity_WhenFlagIsEnabled() throws JsonProcessingException {
+        mockCredentialScope("VerifiableCredential", "UserCredential");
+        mockGetNextIndex();
+
+        mapper.setClaim(claims, userSession);
+
+        var entityCaptor = ArgumentCaptor.forClass(StatusListMappingEntity.class);
+        verify(entityManager).persist(entityCaptor.capture());
+        StatusListMappingEntity capturedEntity = entityCaptor.getValue();
+        Map<?, ?> parsed = new ObjectMapper().readValue(capturedEntity.getMetadata(), Map.class);
+        assertEquals(List.of("VerifiableCredential", "UserCredential"), parsed.get("type"));
+    }
+
+    @Test
+    void shouldFindCredentialTypes_FromParentScope() {
+        mockCredentialScope("VerifiableCredential", "UserCredential");
+
+        List<String> types = mapper.findCredentialTypes();
+
+        assertEquals(List.of("VerifiableCredential", "UserCredential"), types);
+    }
+
+    @Test
+    void shouldReturnEmptyCredentialTypes_WhenNoMatchingScope() {
+        when(mapperModel.getId()).thenReturn("test-mapper-id");
+        when(realm.getClientScopesStream()).thenAnswer(inv -> Stream.empty());
+
+        List<String> types = mapper.findCredentialTypes();
+
+        assertEquals(List.of(), types);
+    }
+
+    @Test
+    void shouldReturnEmptyCredentialTypes_WhenMapperIdIsNull() {
+        when(mapperModel.getId()).thenReturn(null);
+
+        List<String> types = mapper.findCredentialTypes();
+
+        assertEquals(List.of(), types);
+    }
+
+    @Test
+    void shouldReturnNullMetadata_WhenNoClaimPathsAndNoCredentialTypes() {
+        String metadata = mapper.extractMetadata(claims, List.of());
+
+        assertEquals(null, metadata);
+    }
+
     private void mockDefaultRealmConfig() {
         lenient()
                 .when(realm.getAttribute(StatusListConfig.STATUS_LIST_ENABLED))
@@ -460,6 +552,15 @@ class StatusListProtocolMapperTest extends MockKeycloakTest {
         lenient().doReturn(nextIndex).when(statusListRepository).getNextIndex(any(), anyString());
 
         return nextIndex;
+    }
+
+    private void mockCredentialScope(String... types) {
+        String mapperId = "test-mapper-id";
+        lenient().when(mapperModel.getId()).thenReturn(mapperId);
+        lenient().when(clientScope.getProtocol()).thenReturn("oid4vc");
+        lenient().when(clientScope.getProtocolMapperById(mapperId)).thenReturn(mapperModel);
+        lenient().when(clientScope.getAttribute("vc.supported_credential_types")).thenReturn(String.join(",", types));
+        lenient().when(realm.getClientScopesStream()).thenAnswer(inv -> Stream.of(clientScope));
     }
 
     @SuppressWarnings("SameParameterValue")

--- a/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
@@ -18,6 +18,7 @@ import com.adorsys.keycloakstatuslist.jpa.repository.StatusListRepository;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusPage;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusResponse;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusUpdateRequest;
+import com.adorsys.keycloakstatuslist.model.TokenStatus;
 import com.adorsys.keycloakstatuslist.service.StatusListService;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
@@ -149,7 +150,7 @@ class StatusListAdminResourceTest {
         assertEquals("token-1", item.tokenId());
         assertEquals(TEST_USER_ID, item.userId());
         assertEquals(TEST_USERNAME, item.username());
-        assertEquals("SUCCESS", item.status());
+        assertEquals("VALID", item.status());
         assertEquals("list-1", item.statusListId());
         assertEquals(5L, item.index());
         assertEquals("{\"vct\":\"IdentityCredential\"}", item.metadata());
@@ -369,10 +370,14 @@ class StatusListAdminResourceTest {
         assertEquals(5L, payload.status().get(0).index());
         assertEquals("INVALID", payload.status().get(0).status());
 
+        verify(repository).updateMapping(mapping);
+        assertEquals(TokenStatus.INVALID, mapping.getTokenStatus());
+
         CredentialStatusResponse result = (CredentialStatusResponse) response.getEntity();
         assertEquals(TEST_MAPPING_ID, result.id());
         assertEquals("token-1", result.tokenId());
         assertEquals(TEST_USERNAME, result.username());
+        assertEquals("INVALID", result.status());
     }
 
     @Test
@@ -397,6 +402,9 @@ class StatusListAdminResourceTest {
         verify(statusListService).updateStatusList(payloadCaptor.capture(), anyString());
 
         assertEquals("VALID", payloadCaptor.getValue().status().get(0).status());
+
+        verify(repository).updateMapping(mapping);
+        assertEquals(TokenStatus.VALID, mapping.getTokenStatus());
     }
 
     @Test
@@ -442,6 +450,7 @@ class StatusListAdminResourceTest {
         mapping.setStatusListId(statusListId);
         mapping.setIdx(idx);
         mapping.setStatus(StatusListMappingEntity.MappingStatus.SUCCESS);
+        mapping.setTokenStatus(TokenStatus.VALID);
         mapping.setMetadata(metadata);
         mapping.setRealmId(TEST_REALM_ID);
         return mapping;

--- a/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
@@ -3,6 +3,7 @@ package com.adorsys.keycloakstatuslist.resource;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.when;
 import com.adorsys.keycloakstatuslist.exception.StatusListException;
 import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
 import com.adorsys.keycloakstatuslist.jpa.repository.StatusListRepository;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusFilter;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusPage;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusResponse;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusUpdateRequest;
@@ -92,7 +94,7 @@ class StatusListAdminResourceTest {
     void shouldReturn401_WhenNotAuthenticated() {
         doReturn(null).when(resource).authenticateAdmin();
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
     }
@@ -102,7 +104,7 @@ class StatusListAdminResourceTest {
         AdminAuth auth = mockAdminAuth(false);
         doReturn(auth).when(resource).authenticateAdmin();
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
     }
@@ -111,10 +113,10 @@ class StatusListAdminResourceTest {
     void shouldReturnEmptyPage_WhenNoMappingsExist() {
         AdminAuth auth = mockAdminAuth(true);
         doReturn(auth).when(resource).authenticateAdmin();
-        when(repository.countMappings(TEST_REALM_ID)).thenReturn(0L);
-        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of());
+        when(repository.countMappings(anyString(), any())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
@@ -131,14 +133,14 @@ class StatusListAdminResourceTest {
 
         StatusListMappingEntity mapping =
                 createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 5L, "{\"vct\":\"IdentityCredential\"}");
-        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
-        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+        when(repository.countMappings(anyString(), any())).thenReturn(1L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of(mapping));
 
         UserModel user = mock(UserModel.class);
         when(user.getUsername()).thenReturn(TEST_USERNAME);
         when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
@@ -163,11 +165,11 @@ class StatusListAdminResourceTest {
 
         StatusListMappingEntity mapping =
                 createMapping(TEST_MAPPING_ID, "token-1", "deleted-user-id", "list-1", 0L, null);
-        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
-        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+        when(repository.countMappings(anyString(), any())).thenReturn(1L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of(mapping));
         when(userProvider.getUserById(realm, "deleted-user-id")).thenReturn(null);
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
@@ -182,10 +184,10 @@ class StatusListAdminResourceTest {
         doReturn(auth).when(resource).authenticateAdmin();
 
         StatusListMappingEntity mapping = createMapping(TEST_MAPPING_ID, "token-1", null, "list-1", 0L, null);
-        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
-        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+        when(repository.countMappings(anyString(), any())).thenReturn(1L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of(mapping));
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
@@ -199,10 +201,10 @@ class StatusListAdminResourceTest {
     void shouldClampPaginationParameters(int inputOffset, int inputLimit, int expectedOffset, int expectedLimit) {
         AdminAuth auth = mockAdminAuth(true);
         doReturn(auth).when(resource).authenticateAdmin();
-        when(repository.countMappings(TEST_REALM_ID)).thenReturn(0L);
-        when(repository.getMappings(TEST_REALM_ID, expectedOffset, expectedLimit)).thenReturn(List.of());
+        when(repository.countMappings(anyString(), any())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
 
-        Response response = resource.getCredentials(inputOffset, inputLimit);
+        Response response = resource.getCredentials(inputOffset, inputLimit, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
@@ -217,14 +219,14 @@ class StatusListAdminResourceTest {
 
         StatusListMappingEntity mapping1 = createMapping("id-1", "token-1", TEST_USER_ID, "list-1", 0L, null);
         StatusListMappingEntity mapping2 = createMapping("id-2", "token-2", TEST_USER_ID, "list-1", 1L, "{\"vct\":\"PID\"}");
-        when(repository.countMappings(TEST_REALM_ID)).thenReturn(2L);
-        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping1, mapping2));
+        when(repository.countMappings(anyString(), any())).thenReturn(2L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of(mapping1, mapping2));
 
         UserModel user = mock(UserModel.class);
         when(user.getUsername()).thenReturn(TEST_USERNAME);
         when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
         CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
@@ -238,14 +240,14 @@ class StatusListAdminResourceTest {
         doReturn(auth).when(resource).authenticateAdmin();
 
         StatusListMappingEntity mapping = createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 0L, null);
-        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
-        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+        when(repository.countMappings(anyString(), any())).thenReturn(1L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of(mapping));
 
         UserModel user = mock(UserModel.class);
         when(user.getUsername()).thenReturn(TEST_USERNAME);
         when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
         assertNull(page.items().get(0).metadata());
@@ -258,9 +260,149 @@ class StatusListAdminResourceTest {
         when(realm.getClientByClientId("realm-management")).thenReturn(null);
         when(realm.getClientByClientId("master-realm")).thenReturn(null);
 
-        Response response = resource.getCredentials(0, 20);
+        Response response = resource.getCredentials(0, 20, null, null, null);
 
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    // --- GET filter tests ---
+
+    @Test
+    void shouldFilterByUsername_WhenUserExists() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        UserModel user = mock(UserModel.class);
+        when(user.getId()).thenReturn(TEST_USER_ID);
+        when(userProvider.getUserByUsername(realm, TEST_USERNAME)).thenReturn(user);
+
+        StatusListMappingEntity mapping =
+                createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 0L, null);
+
+        ArgumentCaptor<CredentialStatusFilter> filterCaptor = ArgumentCaptor.forClass(CredentialStatusFilter.class);
+        when(repository.countMappings(anyString(), filterCaptor.capture())).thenReturn(1L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of(mapping));
+        when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
+        when(user.getUsername()).thenReturn(TEST_USERNAME);
+
+        Response response = resource.getCredentials(0, 20, TEST_USERNAME, null, null);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(TEST_USER_ID, filterCaptor.getValue().userId());
+    }
+
+    @Test
+    void shouldReturnEmptyPage_WhenFilteredUsernameNotFound() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+        when(userProvider.getUserByUsername(realm, "nonexistent")).thenReturn(null);
+
+        ArgumentCaptor<CredentialStatusFilter> filterCaptor = ArgumentCaptor.forClass(CredentialStatusFilter.class);
+        when(repository.countMappings(anyString(), filterCaptor.capture())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
+
+        Response response = resource.getCredentials(0, 20, "nonexistent", null, null);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(StatusListAdminResource.NON_MATCHING_USER_ID, filterCaptor.getValue().userId());
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        assertEquals(0, page.total());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"VALID, VALID", "INVALID, INVALID"})
+    void shouldFilterByStatus(String inputStatus, String expectedEnum) {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        ArgumentCaptor<CredentialStatusFilter> filterCaptor = ArgumentCaptor.forClass(CredentialStatusFilter.class);
+        when(repository.countMappings(anyString(), filterCaptor.capture())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
+
+        Response response = resource.getCredentials(0, 20, null, inputStatus, null);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(TokenStatus.valueOf(expectedEnum), filterCaptor.getValue().tokenStatus());
+    }
+
+    @Test
+    void shouldReturn400_WhenStatusFilterIsInvalid() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        Response response = resource.getCredentials(0, 20, null, "SUSPENDED", null);
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void shouldFilterByClaims() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        ArgumentCaptor<CredentialStatusFilter> filterCaptor = ArgumentCaptor.forClass(CredentialStatusFilter.class);
+        when(repository.countMappings(anyString(), filterCaptor.capture())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
+
+        Response response = resource.getCredentials(0, 20, null, null, List.of("IdentityCredential"));
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(List.of("IdentityCredential"), filterCaptor.getValue().claims());
+    }
+
+    @Test
+    void shouldFilterByMultipleClaims() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        ArgumentCaptor<CredentialStatusFilter> filterCaptor = ArgumentCaptor.forClass(CredentialStatusFilter.class);
+        when(repository.countMappings(anyString(), filterCaptor.capture())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
+
+        List<String> claims = List.of("IdentityCredential", "alice@example.com");
+        Response response = resource.getCredentials(0, 20, null, null, claims);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(claims, filterCaptor.getValue().claims());
+    }
+
+    @Test
+    void shouldCombineAllFilters() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        UserModel user = mock(UserModel.class);
+        when(user.getId()).thenReturn(TEST_USER_ID);
+        when(userProvider.getUserByUsername(realm, TEST_USERNAME)).thenReturn(user);
+
+        ArgumentCaptor<CredentialStatusFilter> filterCaptor = ArgumentCaptor.forClass(CredentialStatusFilter.class);
+        when(repository.countMappings(anyString(), filterCaptor.capture())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
+
+        List<String> claims = List.of("PID");
+        Response response = resource.getCredentials(0, 20, TEST_USERNAME, "INVALID", claims);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        CredentialStatusFilter filter = filterCaptor.getValue();
+        assertEquals(TEST_USER_ID, filter.userId());
+        assertEquals(TokenStatus.INVALID, filter.tokenStatus());
+        assertEquals(claims, filter.claims());
+    }
+
+    @Test
+    void shouldIgnoreBlankClaimsEntries() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        ArgumentCaptor<CredentialStatusFilter> filterCaptor = ArgumentCaptor.forClass(CredentialStatusFilter.class);
+        when(repository.countMappings(anyString(), filterCaptor.capture())).thenReturn(0L);
+        when(repository.getMappings(anyString(), any(), anyInt(), anyInt())).thenReturn(List.of());
+
+        List<String> claims = List.of("PID", "", "  ");
+        Response response = resource.getCredentials(0, 20, null, null, claims);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        assertEquals(List.of("PID"), filterCaptor.getValue().claims());
     }
 
     // --- PUT tests ---

--- a/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
@@ -1,0 +1,276 @@
+package com.adorsys.keycloakstatuslist.resource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
+import com.adorsys.keycloakstatuslist.jpa.repository.StatusListRepository;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusPage;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusResponse;
+import jakarta.ws.rs.core.Response;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.keycloak.models.ClientModel;
+import org.keycloak.models.KeycloakContext;
+import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
+import org.keycloak.models.RoleModel;
+import org.keycloak.models.UserModel;
+import org.keycloak.models.UserProvider;
+import org.keycloak.representations.AccessToken;
+import org.keycloak.services.resources.admin.AdminAuth;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StatusListAdminResourceTest {
+
+    private static final String TEST_REALM_ID = "test-realm-id";
+    private static final String TEST_USER_ID = "user-123";
+    private static final String TEST_USERNAME = "testuser";
+
+    @Mock
+    private KeycloakSession session;
+
+    @Mock
+    private KeycloakContext context;
+
+    @Mock
+    private RealmModel realm;
+
+    @Mock
+    private StatusListRepository repository;
+
+    @Mock
+    private UserProvider userProvider;
+
+    @Mock
+    private ClientModel realmManagementClient;
+
+    @Mock
+    private RoleModel realmAdminRole;
+
+    private StatusListAdminResource resource;
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(session.getContext()).thenReturn(context);
+        lenient().when(context.getRealm()).thenReturn(realm);
+        lenient().when(realm.getId()).thenReturn(TEST_REALM_ID);
+        lenient().when(session.users()).thenReturn(userProvider);
+
+        resource = spy(new StatusListAdminResource(session, repository));
+    }
+
+    @Test
+    void shouldReturn401_WhenNotAuthenticated() {
+        doReturn(null).when(resource).authenticateAdmin();
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void shouldReturn403_WhenNotRealmAdmin() {
+        AdminAuth auth = mockAdminAuth(false);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void shouldReturnEmptyPage_WhenNoMappingsExist() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+        when(repository.countMappings(TEST_REALM_ID)).thenReturn(0L);
+        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of());
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        assertEquals(0, page.total());
+        assertEquals(0, page.items().size());
+        assertEquals(0, page.offset());
+        assertEquals(20, page.limit());
+    }
+
+    @Test
+    void shouldReturnMappingsWithUserDetails() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping =
+                createMapping("token-1", TEST_USER_ID, "list-1", 5L, "{\"vct\":\"IdentityCredential\"}");
+        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
+        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+
+        UserModel user = mock(UserModel.class);
+        when(user.getUsername()).thenReturn(TEST_USERNAME);
+        when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        assertEquals(1, page.total());
+        assertEquals(1, page.items().size());
+
+        CredentialStatusResponse item = page.items().get(0);
+        assertEquals("token-1", item.tokenId());
+        assertEquals(TEST_USER_ID, item.userId());
+        assertEquals(TEST_USERNAME, item.username());
+        assertEquals("SUCCESS", item.status());
+        assertEquals("list-1", item.statusListId());
+        assertEquals(5L, item.index());
+        assertEquals("{\"vct\":\"IdentityCredential\"}", item.metadata());
+    }
+
+    @Test
+    void shouldReturnNullUsername_WhenUserNotFound() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping = createMapping("token-1", "deleted-user-id", "list-1", 0L, null);
+        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
+        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+        when(userProvider.getUserById(realm, "deleted-user-id")).thenReturn(null);
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        CredentialStatusResponse item = page.items().get(0);
+        assertEquals("deleted-user-id", item.userId());
+        assertNull(item.username());
+    }
+
+    @Test
+    void shouldReturnNullUsername_WhenUserIdIsNull() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping = createMapping("token-1", null, "list-1", 0L, null);
+        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
+        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        CredentialStatusResponse item = page.items().get(0);
+        assertNull(item.userId());
+        assertNull(item.username());
+    }
+
+    @ParameterizedTest
+    @CsvSource({"-5, 20, 0, 20", "0, 200, 0, 100", "0, 0, 0, 1", "10, 5, 10, 5"})
+    void shouldClampPaginationParameters(int inputOffset, int inputLimit, int expectedOffset, int expectedLimit) {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+        when(repository.countMappings(TEST_REALM_ID)).thenReturn(0L);
+        when(repository.getMappings(TEST_REALM_ID, expectedOffset, expectedLimit)).thenReturn(List.of());
+
+        Response response = resource.getCredentials(inputOffset, inputLimit);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        assertEquals(expectedOffset, page.offset());
+        assertEquals(expectedLimit, page.limit());
+    }
+
+    @Test
+    void shouldReturnMultipleMappings() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping1 = createMapping("token-1", TEST_USER_ID, "list-1", 0L, null);
+        StatusListMappingEntity mapping2 = createMapping("token-2", TEST_USER_ID, "list-1", 1L, "{\"vct\":\"PID\"}");
+        when(repository.countMappings(TEST_REALM_ID)).thenReturn(2L);
+        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping1, mapping2));
+
+        UserModel user = mock(UserModel.class);
+        when(user.getUsername()).thenReturn(TEST_USERNAME);
+        when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        assertEquals(2, page.total());
+        assertEquals(2, page.items().size());
+    }
+
+    @Test
+    void shouldReturnNullMetadata_WhenNotSet() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping = createMapping("token-1", TEST_USER_ID, "list-1", 0L, null);
+        when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
+        when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
+
+        UserModel user = mock(UserModel.class);
+        when(user.getUsername()).thenReturn(TEST_USERNAME);
+        when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
+
+        Response response = resource.getCredentials(0, 20);
+
+        CredentialStatusPage page = (CredentialStatusPage) response.getEntity();
+        assertNull(page.items().get(0).metadata());
+    }
+
+    @Test
+    void shouldReturn403_WhenRealmManagementClientNotFound() {
+        AdminAuth auth = mockAdminAuth(false);
+        doReturn(auth).when(resource).authenticateAdmin();
+        when(realm.getClientByClientId("realm-management")).thenReturn(null);
+        when(realm.getClientByClientId("master-realm")).thenReturn(null);
+
+        Response response = resource.getCredentials(0, 20);
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    // --- Helper methods ---
+
+    private AdminAuth mockAdminAuth(boolean isRealmAdmin) {
+        UserModel adminUser = mock(UserModel.class);
+        ClientModel adminClient = mock(ClientModel.class);
+
+        lenient().when(realm.getClientByClientId("realm-management")).thenReturn(realmManagementClient);
+        lenient().when(realmManagementClient.getRole("realm-admin")).thenReturn(realmAdminRole);
+
+        if (isRealmAdmin) {
+            lenient().when(adminUser.hasRole(realmAdminRole)).thenReturn(true);
+            lenient().when(adminClient.hasScope(realmAdminRole)).thenReturn(true);
+        }
+
+        return new AdminAuth(realm, new AccessToken(), adminUser, adminClient);
+    }
+
+    private StatusListMappingEntity createMapping(
+            String tokenId, String userId, String statusListId, long idx, String metadata) {
+        StatusListMappingEntity mapping = new StatusListMappingEntity();
+        mapping.setTokenId(tokenId);
+        mapping.setUserId(userId);
+        mapping.setStatusListId(statusListId);
+        mapping.setIdx(idx);
+        mapping.setStatus(StatusListMappingEntity.MappingStatus.SUCCESS);
+        mapping.setMetadata(metadata);
+        mapping.setRealmId(TEST_REALM_ID);
+        return mapping;
+    }
+}

--- a/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/resource/StatusListAdminResourceTest.java
@@ -2,16 +2,23 @@ package com.adorsys.keycloakstatuslist.resource;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.adorsys.keycloakstatuslist.exception.StatusListException;
 import com.adorsys.keycloakstatuslist.jpa.entity.StatusListMappingEntity;
 import com.adorsys.keycloakstatuslist.jpa.repository.StatusListRepository;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusPage;
 import com.adorsys.keycloakstatuslist.model.CredentialStatusResponse;
+import com.adorsys.keycloakstatuslist.model.CredentialStatusUpdateRequest;
+import com.adorsys.keycloakstatuslist.service.StatusListService;
 import jakarta.ws.rs.core.Response;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -19,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.keycloak.models.ClientModel;
 import org.keycloak.models.KeycloakContext;
 import org.keycloak.models.KeycloakSession;
@@ -28,6 +37,7 @@ import org.keycloak.models.UserModel;
 import org.keycloak.models.UserProvider;
 import org.keycloak.representations.AccessToken;
 import org.keycloak.services.resources.admin.AdminAuth;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -37,6 +47,7 @@ class StatusListAdminResourceTest {
     private static final String TEST_REALM_ID = "test-realm-id";
     private static final String TEST_USER_ID = "user-123";
     private static final String TEST_USERNAME = "testuser";
+    private static final String TEST_MAPPING_ID = "mapping-uuid-1";
 
     @Mock
     private KeycloakSession session;
@@ -49,6 +60,9 @@ class StatusListAdminResourceTest {
 
     @Mock
     private StatusListRepository repository;
+
+    @Mock
+    private StatusListService statusListService;
 
     @Mock
     private UserProvider userProvider;
@@ -68,8 +82,10 @@ class StatusListAdminResourceTest {
         lenient().when(realm.getId()).thenReturn(TEST_REALM_ID);
         lenient().when(session.users()).thenReturn(userProvider);
 
-        resource = spy(new StatusListAdminResource(session, repository));
+        resource = spy(new StatusListAdminResource(session, repository, statusListService));
     }
+
+    // --- GET tests ---
 
     @Test
     void shouldReturn401_WhenNotAuthenticated() {
@@ -113,7 +129,7 @@ class StatusListAdminResourceTest {
         doReturn(auth).when(resource).authenticateAdmin();
 
         StatusListMappingEntity mapping =
-                createMapping("token-1", TEST_USER_ID, "list-1", 5L, "{\"vct\":\"IdentityCredential\"}");
+                createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 5L, "{\"vct\":\"IdentityCredential\"}");
         when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
         when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
 
@@ -129,6 +145,7 @@ class StatusListAdminResourceTest {
         assertEquals(1, page.items().size());
 
         CredentialStatusResponse item = page.items().get(0);
+        assertEquals(TEST_MAPPING_ID, item.id());
         assertEquals("token-1", item.tokenId());
         assertEquals(TEST_USER_ID, item.userId());
         assertEquals(TEST_USERNAME, item.username());
@@ -143,7 +160,8 @@ class StatusListAdminResourceTest {
         AdminAuth auth = mockAdminAuth(true);
         doReturn(auth).when(resource).authenticateAdmin();
 
-        StatusListMappingEntity mapping = createMapping("token-1", "deleted-user-id", "list-1", 0L, null);
+        StatusListMappingEntity mapping =
+                createMapping(TEST_MAPPING_ID, "token-1", "deleted-user-id", "list-1", 0L, null);
         when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
         when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
         when(userProvider.getUserById(realm, "deleted-user-id")).thenReturn(null);
@@ -162,7 +180,7 @@ class StatusListAdminResourceTest {
         AdminAuth auth = mockAdminAuth(true);
         doReturn(auth).when(resource).authenticateAdmin();
 
-        StatusListMappingEntity mapping = createMapping("token-1", null, "list-1", 0L, null);
+        StatusListMappingEntity mapping = createMapping(TEST_MAPPING_ID, "token-1", null, "list-1", 0L, null);
         when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
         when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
 
@@ -196,8 +214,8 @@ class StatusListAdminResourceTest {
         AdminAuth auth = mockAdminAuth(true);
         doReturn(auth).when(resource).authenticateAdmin();
 
-        StatusListMappingEntity mapping1 = createMapping("token-1", TEST_USER_ID, "list-1", 0L, null);
-        StatusListMappingEntity mapping2 = createMapping("token-2", TEST_USER_ID, "list-1", 1L, "{\"vct\":\"PID\"}");
+        StatusListMappingEntity mapping1 = createMapping("id-1", "token-1", TEST_USER_ID, "list-1", 0L, null);
+        StatusListMappingEntity mapping2 = createMapping("id-2", "token-2", TEST_USER_ID, "list-1", 1L, "{\"vct\":\"PID\"}");
         when(repository.countMappings(TEST_REALM_ID)).thenReturn(2L);
         when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping1, mapping2));
 
@@ -218,7 +236,7 @@ class StatusListAdminResourceTest {
         AdminAuth auth = mockAdminAuth(true);
         doReturn(auth).when(resource).authenticateAdmin();
 
-        StatusListMappingEntity mapping = createMapping("token-1", TEST_USER_ID, "list-1", 0L, null);
+        StatusListMappingEntity mapping = createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 0L, null);
         when(repository.countMappings(TEST_REALM_ID)).thenReturn(1L);
         when(repository.getMappings(TEST_REALM_ID, 0, 20)).thenReturn(List.of(mapping));
 
@@ -244,6 +262,160 @@ class StatusListAdminResourceTest {
         assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
     }
 
+    // --- PUT tests ---
+
+    @Test
+    void putShouldReturn401_WhenNotAuthenticated() {
+        doReturn(null).when(resource).authenticateAdmin();
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("INVALID"));
+
+        assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void putShouldReturn403_WhenNotRealmAdmin() {
+        AdminAuth auth = mockAdminAuth(false);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("INVALID"));
+
+        assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void putShouldReturn400_WhenRequestIsNull() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, null);
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"  "})
+    void putShouldReturn400_WhenStatusIsBlank(String status) {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest(status));
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void putShouldReturn400_WhenStatusIsUnknown() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        Response response =
+                resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("SUSPENDED"));
+
+        assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void putShouldReturn404_WhenMappingNotFound() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+        when(repository.findById(TEST_MAPPING_ID)).thenReturn(null);
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("INVALID"));
+
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void putShouldReturn404_WhenMappingBelongsToDifferentRealm() {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping =
+                createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 5L, null);
+        mapping.setRealmId("other-realm-id");
+        when(repository.findById(TEST_MAPPING_ID)).thenReturn(mapping);
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("INVALID"));
+
+        assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response.getStatus());
+    }
+
+    @Test
+    void putShouldRevokeCredentialSuccessfully() throws Exception {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping =
+                createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 5L, "{\"vct\":\"PID\"}");
+        when(repository.findById(TEST_MAPPING_ID)).thenReturn(mapping);
+
+        UserModel user = mock(UserModel.class);
+        when(user.getUsername()).thenReturn(TEST_USERNAME);
+        when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("INVALID"));
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+        ArgumentCaptor<StatusListService.StatusListPayload> payloadCaptor =
+                ArgumentCaptor.forClass(StatusListService.StatusListPayload.class);
+        verify(statusListService).updateStatusList(payloadCaptor.capture(), anyString());
+
+        StatusListService.StatusListPayload payload = payloadCaptor.getValue();
+        assertEquals("list-1", payload.listId());
+        assertEquals(1, payload.status().size());
+        assertEquals(5L, payload.status().get(0).index());
+        assertEquals("INVALID", payload.status().get(0).status());
+
+        CredentialStatusResponse result = (CredentialStatusResponse) response.getEntity();
+        assertEquals(TEST_MAPPING_ID, result.id());
+        assertEquals("token-1", result.tokenId());
+        assertEquals(TEST_USERNAME, result.username());
+    }
+
+    @Test
+    void putShouldRevalidateCredentialSuccessfully() throws Exception {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping =
+                createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 3L, null);
+        when(repository.findById(TEST_MAPPING_ID)).thenReturn(mapping);
+
+        UserModel user = mock(UserModel.class);
+        when(user.getUsername()).thenReturn(TEST_USERNAME);
+        when(userProvider.getUserById(realm, TEST_USER_ID)).thenReturn(user);
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("VALID"));
+
+        assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
+
+        ArgumentCaptor<StatusListService.StatusListPayload> payloadCaptor =
+                ArgumentCaptor.forClass(StatusListService.StatusListPayload.class);
+        verify(statusListService).updateStatusList(payloadCaptor.capture(), anyString());
+
+        assertEquals("VALID", payloadCaptor.getValue().status().get(0).status());
+    }
+
+    @Test
+    void putShouldReturn502_WhenStatusListServerFails() throws Exception {
+        AdminAuth auth = mockAdminAuth(true);
+        doReturn(auth).when(resource).authenticateAdmin();
+
+        StatusListMappingEntity mapping =
+                createMapping(TEST_MAPPING_ID, "token-1", TEST_USER_ID, "list-1", 5L, null);
+        when(repository.findById(TEST_MAPPING_ID)).thenReturn(mapping);
+        doThrow(new StatusListException("server unreachable"))
+                .when(statusListService)
+                .updateStatusList(any(), anyString());
+
+        Response response = resource.updateCredentialStatus(TEST_MAPPING_ID, new CredentialStatusUpdateRequest("INVALID"));
+
+        assertEquals(Response.Status.BAD_GATEWAY.getStatusCode(), response.getStatus());
+    }
+
     // --- Helper methods ---
 
     private AdminAuth mockAdminAuth(boolean isRealmAdmin) {
@@ -262,8 +434,9 @@ class StatusListAdminResourceTest {
     }
 
     private StatusListMappingEntity createMapping(
-            String tokenId, String userId, String statusListId, long idx, String metadata) {
+            String id, String tokenId, String userId, String statusListId, long idx, String metadata) {
         StatusListMappingEntity mapping = new StatusListMappingEntity();
+        mapping.setId(id);
         mapping.setTokenId(tokenId);
         mapping.setUserId(userId);
         mapping.setStatusListId(statusListId);

--- a/src/test/java/com/adorsys/keycloakstatuslist/service/CustomHttpClientTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/service/CustomHttpClientTest.java
@@ -4,12 +4,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.adorsys.keycloakstatuslist.config.StatusListConfig;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.List;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -24,6 +26,8 @@ import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.util.TimeValue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.api.io.TempDir;
 import org.keycloak.models.RealmModel;
 
@@ -160,6 +164,83 @@ class CustomHttpClientTest {
         HttpHost proxy = CustomHttpClient.resolveProxy(env::get);
 
         assertNull(proxy);
+    }
+
+    @Test
+    void resolveNoProxyShouldParsePatterns() {
+        Map<String, String> env = Map.of("NO_PROXY", "localhost,.example.com,internal.corp");
+
+        List<String> patterns = CustomHttpClient.resolveNoProxy(env::get);
+
+        assertEquals(List.of("localhost", ".example.com", "internal.corp"), patterns);
+    }
+
+    @Test
+    void resolveNoProxyShouldPreferUppercaseOverLowercase() {
+        Map<String, String> env = new HashMap<>();
+        env.put("NO_PROXY", "upper.com");
+        env.put("no_proxy", "lower.com");
+
+        List<String> patterns = CustomHttpClient.resolveNoProxy(env::get);
+
+        assertEquals(List.of("upper.com"), patterns);
+    }
+
+    @Test
+    void resolveNoProxyShouldFallBackToLowercaseVar() {
+        Map<String, String> env = Map.of("no_proxy", "fallback.com");
+
+        List<String> patterns = CustomHttpClient.resolveNoProxy(env::get);
+
+        assertEquals(List.of("fallback.com"), patterns);
+    }
+
+    @Test
+    void resolveNoProxyShouldReturnEmptyListWhenNoEnvVarSet() {
+        List<String> patterns = CustomHttpClient.resolveNoProxy(name -> null);
+
+        assertTrue(patterns.isEmpty());
+    }
+
+    @Test
+    void resolveNoProxyShouldTrimWhitespaceAndSkipEmptyEntries() {
+        Map<String, String> env = Map.of("NO_PROXY", " host1 , , host2 ");
+
+        List<String> patterns = CustomHttpClient.resolveNoProxy(env::get);
+
+        assertEquals(List.of("host1", "host2"), patterns);
+    }
+
+    @Test
+    void resolveNoProxyShouldLowercasePatterns() {
+        Map<String, String> env = Map.of("NO_PROXY", "MyHost.Example.COM");
+
+        List<String> patterns = CustomHttpClient.resolveNoProxy(env::get);
+
+        assertEquals(List.of("myhost.example.com"), patterns);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "api.example.com, .example.com, true",
+        "example.com, .example.com, true",
+        "notexample.com, .example.com, false",
+        "api.example.com, example.com, true",
+        "example.com, example.com, true",
+        "notexample.com, example.com, false",
+        "anything.at.all, *, true",
+        "localhost, localhost, true",
+        "UPPER.EXAMPLE.COM, example.com, true",
+        "127.0.0.1, 127.0.0.1, true",
+        "10.0.0.1, 127.0.0.1, false",
+    })
+    void isNoProxyHostShouldMatchCorrectly(String hostname, String pattern, boolean expected) {
+        assertEquals(expected, CustomHttpClient.isNoProxyHost(hostname, List.of(pattern)));
+    }
+
+    @Test
+    void isNoProxyHostShouldReturnFalseForEmptyPatterns() {
+        assertFalse(CustomHttpClient.isNoProxyHost("example.com", List.of()));
     }
 
     @Test

--- a/src/test/java/com/adorsys/keycloakstatuslist/service/CustomHttpClientTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/service/CustomHttpClientTest.java
@@ -3,14 +3,18 @@ package com.adorsys.keycloakstatuslist.service;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.adorsys.keycloakstatuslist.config.StatusListConfig;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -86,6 +90,71 @@ class CustomHttpClientTest {
 
         assertEquals(TimeValue.ofSeconds(1), first);
         assertEquals(TimeValue.ofSeconds(4), third);
+    }
+
+    @Test
+    void resolveProxyShouldParseFromAllEnvVarCandidates() {
+        String[] candidates = {"HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"};
+        for (String envVarName : candidates) {
+            Map<String, String> env = new HashMap<>();
+            env.put(envVarName, "http://squid-proxy.infra.svc.cluster.local:8888");
+
+            HttpHost proxy = CustomHttpClient.resolveProxy(env::get);
+
+            assertNotNull(proxy, "Expected proxy for env var " + envVarName);
+            assertEquals("http", proxy.getSchemeName());
+            assertEquals("squid-proxy.infra.svc.cluster.local", proxy.getHostName());
+            assertEquals(8888, proxy.getPort());
+        }
+    }
+
+    @Test
+    void resolveProxyShouldPreferHttpsOverHttp() {
+        Map<String, String> env = new HashMap<>();
+        env.put("HTTPS_PROXY", "http://https-proxy:3128");
+        env.put("HTTP_PROXY", "http://http-proxy:8080");
+
+        HttpHost proxy = CustomHttpClient.resolveProxy(env::get);
+
+        assertNotNull(proxy);
+        assertEquals("https-proxy", proxy.getHostName());
+        assertEquals(3128, proxy.getPort());
+    }
+
+    @Test
+    void resolveProxyShouldReturnNullWhenNoEnvVarSet() {
+        HttpHost proxy = CustomHttpClient.resolveProxy(name -> null);
+
+        assertNull(proxy);
+    }
+
+    @Test
+    void resolveProxyShouldDefaultPortForHttpScheme() {
+        Map<String, String> env = Map.of("HTTP_PROXY", "http://proxy-host");
+
+        HttpHost proxy = CustomHttpClient.resolveProxy(env::get);
+
+        assertNotNull(proxy);
+        assertEquals(80, proxy.getPort());
+    }
+
+    @Test
+    void resolveProxyShouldDefaultPortForHttpsScheme() {
+        Map<String, String> env = Map.of("HTTPS_PROXY", "https://proxy-host");
+
+        HttpHost proxy = CustomHttpClient.resolveProxy(env::get);
+
+        assertNotNull(proxy);
+        assertEquals(443, proxy.getPort());
+    }
+
+    @Test
+    void resolveProxyShouldReturnNullForInvalidUrl() {
+        Map<String, String> env = Map.of("HTTPS_PROXY", "not a valid url ://");
+
+        HttpHost proxy = CustomHttpClient.resolveProxy(env::get);
+
+        assertNull(proxy);
     }
 
     private HttpRequestRetryStrategy getRetryStrategy(int maxRetries) {

--- a/src/test/java/com/adorsys/keycloakstatuslist/service/CustomHttpClientTest.java
+++ b/src/test/java/com/adorsys/keycloakstatuslist/service/CustomHttpClientTest.java
@@ -10,16 +10,21 @@ import static org.mockito.Mockito.when;
 import com.adorsys.keycloakstatuslist.config.StatusListConfig;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+import javax.net.ssl.SSLContext;
 import org.apache.hc.client5.http.HttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
 import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.util.TimeValue;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.keycloak.models.RealmModel;
 
 class CustomHttpClientTest {
@@ -156,6 +161,95 @@ class CustomHttpClientTest {
 
         assertNull(proxy);
     }
+
+    @Test
+    void buildSslContextShouldReturnNullWhenNoTlsConfigured() {
+        StatusListConfig config = configWithTls(false, null);
+
+        SSLContext result = CustomHttpClient.buildSslContext(config);
+
+        assertNull(result);
+    }
+
+    @Test
+    void buildSslContextShouldReturnContextWhenTrustAllEnabled() {
+        StatusListConfig config = configWithTls(true, null);
+
+        SSLContext result = CustomHttpClient.buildSslContext(config);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void buildSslContextShouldReturnContextForValidCaCert(@TempDir Path tempDir) throws Exception {
+        Path certFile = tempDir.resolve("ca.crt");
+        Files.writeString(certFile, TEST_CA_PEM);
+
+        StatusListConfig config = configWithTls(false, certFile.toString());
+
+        SSLContext result = CustomHttpClient.buildSslContext(config);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    void buildSslContextShouldFallBackToNullForMissingCaCertFile() {
+        StatusListConfig config = configWithTls(false, "/nonexistent/ca.crt");
+
+        SSLContext result = CustomHttpClient.buildSslContext(config);
+
+        assertNull(result);
+    }
+
+    @Test
+    void buildConnectionManagerShouldReturnNullWhenNoTlsConfigured() {
+        StatusListConfig config = configWithTls(false, null);
+
+        HttpClientConnectionManager result = CustomHttpClient.buildConnectionManager(config);
+
+        assertNull(result);
+    }
+
+    @Test
+    void buildConnectionManagerShouldReturnManagerWhenTrustAllEnabled() {
+        StatusListConfig config = configWithTls(true, null);
+
+        HttpClientConnectionManager result = CustomHttpClient.buildConnectionManager(config);
+
+        assertNotNull(result);
+    }
+
+    private StatusListConfig configWithTls(boolean trustAll, String caCertPath) {
+        RealmModel realm = mock(RealmModel.class);
+        if (trustAll) {
+            when(realm.getAttribute(StatusListConfig.STATUS_LIST_TLS_TRUST_ALL)).thenReturn("true");
+        }
+        if (caCertPath != null) {
+            when(realm.getAttribute(StatusListConfig.STATUS_LIST_TLS_CA_CERT_PATH)).thenReturn(caCertPath);
+        }
+        return new StatusListConfig(realm);
+    }
+
+    private static final String TEST_CA_PEM =
+            "-----BEGIN CERTIFICATE-----\n"
+                    + "MIIDBTCCAe2gAwIBAgIUZ0BfKEPgqHS63KWkX3pC3nuvvKEwDQYJKoZIhvcNAQEL\n"
+                    + "BQAwEjEQMA4GA1UEAwwHVGVzdCBDQTAeFw0yNjA2MjUxMjA2MjZaFw0yNzA2MjUx\n"
+                    + "MjA2MjZaMBIxEDAOBgNVBAMMB1Rlc3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IB\n"
+                    + "DwAwggEKAoIBAQDuIObFSYy/zTWPFhPhaLh8Q8JKkJjCmpye04hYFg212FWSV9iS\n"
+                    + "CkEIhEhsA9zm6hMzHAcBTCJ1hlM/CHJ7LA9bb0o4tO+lnP3a/kBEG7RPVD4f0run\n"
+                    + "sSTjGFrci4SAWCu8RhNV7KH6jv+6315w6onSO6RPyUEzodKP8D0NE3aTasyKpaW1\n"
+                    + "mn4dP+CrYnutHegQQNM+gxAqTbrL9ghMtt2cR//vOxaMSrL7N+IfTEu1qxVqeqU5\n"
+                    + "pgUsUNG5XNAjhANU5zfhR3TmZWm3pjhiGu+kO5cFgjDYeEFwiqhzvxjyhs1RA89Z\n"
+                    + "pvgbz5HtiAhEDrRH3nyiswzOjb8IcIrLxUO5AgMBAAGjUzBRMB0GA1UdDgQWBBQd\n"
+                    + "05/+gyT8HVBAHZvC1vWbz87e8jAfBgNVHSMEGDAWgBQd05/+gyT8HVBAHZvC1vWb\n"
+                    + "z87e8jAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBOfXtezUxP\n"
+                    + "CUFklnuon3No/st1Hff6KedmLAmtCDrELuhEMMHh3kINmMcnR2jyXadSO3FIjcc5\n"
+                    + "VVTlj37g3+QRKJuFq18VNDnTT95ErzRPFQe4iBMcrxhNmuVJFx2TIgMtQUEljFJe\n"
+                    + "OlrsqzyPkJ39NIN8n7EAg7a5fIMe+lf0bm+VzsQ0i9O0BRFF5kB1lZbOh2n2rJtJ\n"
+                    + "6tvSzFaVh+YFMGhbspX5roRHFmM4IwiPSW8egEBSa6FkUY1kbLuo8sIBCwASmWBb\n"
+                    + "YQKr1usSnpXvftbJyMKGEFFfLYlQz8NxwgO+QBk2HH2WuNffKU7bf4lChsX6fPmk\n"
+                    + "zwk6Xo03geo5\n"
+                    + "-----END CERTIFICATE-----\n";
 
     private HttpRequestRetryStrategy getRetryStrategy(int maxRetries) {
         try {


### PR DESCRIPTION
Hi, thanks for the great work on that provider:)

The PR add support for additional configurations on the HTTP-Client:

- support the standard env vars for proxy configuration in Keycloak
- support custom CAs to be trusted
- only for testing: support for disabling SSL Verification